### PR TITLE
fix windows compile

### DIFF
--- a/src/crypto/random.c
+++ b/src/crypto/random.c
@@ -57,8 +57,8 @@ static void generate_system_random_bytes(size_t n, void *result);
 #if defined(_WIN32)
 
 #include <stdio.h>
-#include <wincrypt.h>
 #include <windows.h>
+#include <wincrypt.h>
 
 static void generate_system_random_bytes(size_t n, void *result)
 {

--- a/src/device/device_ledger.cpp
+++ b/src/device/device_ledger.cpp
@@ -1087,7 +1087,7 @@ bool device_ledger::sc_secret_add(crypto::secret_key &r, const crypto::secret_ke
 	return true;
 }
 
-crypto::secret_key device_ledger::generate_keys(crypto::public_key &pub, crypto::secret_key &sec, const crypto::secret_key &recovery_key, bool recover)
+crypto::secret_key device_ledger::generate_legacy_keys(crypto::public_key &pub, crypto::secret_key &sec, const crypto::secret_key &recovery_key, bool recover)
 {
 	AUTO_LOCK_CMD();
 	if(recover)

--- a/src/device/device_ledger.hpp
+++ b/src/device/device_ledger.hpp
@@ -196,7 +196,7 @@ class device_ledger : public hw::device
 	bool scalarmultKey(rct::key &aP, const rct::key &P, const rct::key &a) override;
 	bool scalarmultBase(rct::key &aG, const rct::key &a) override;
 	bool sc_secret_add(crypto::secret_key &r, const crypto::secret_key &a, const crypto::secret_key &b) override;
-	crypto::secret_key generate_keys(crypto::public_key &pub, crypto::secret_key &sec, const crypto::secret_key &recovery_key = crypto::secret_key(), bool recover = false) override;
+	crypto::secret_key generate_legacy_keys(crypto::public_key &pub, crypto::secret_key &sec, const crypto::secret_key &recovery_key = crypto::secret_key(), bool recover = false) override;
 	bool generate_key_derivation(const crypto::public_key &pub, const crypto::secret_key &sec, crypto::key_derivation &derivation) override;
 	bool conceal_derivation(crypto::key_derivation &derivation, const crypto::public_key &tx_pub_key, const std::vector<crypto::public_key> &additional_tx_pub_keys, const crypto::key_derivation &main_derivation, const std::vector<crypto::key_derivation> &additional_derivations) override;
 	bool derivation_to_scalar(const crypto::key_derivation &derivation, const size_t output_index, crypto::ec_scalar &res) override;


### PR DESCRIPTION
- rename `generate_keys` to `generate_legacy_keys`
- fix include dependancy