### PR TITLE
fix wrong namespaces

### DIFF
--- a/src/blockchain_utilities/blockchain_blackball.cpp
+++ b/src/blockchain_utilities/blockchain_blackball.cpp
@@ -86,7 +86,7 @@ struct hash<output_data>
 static std::string get_default_db_path()
 {
 	boost::filesystem::path dir = tools::get_default_data_dir();
-	// remove .bitmonero, replace with .shared-ringdb
+	// remove .ryo, replace with .shared-ringdb
 	dir = dir.remove_filename();
 	dir /= ".shared-ringdb";
 	return dir.string();

--- a/src/wallet/api/address_book.cpp
+++ b/src/wallet/api/address_book.cpp
@@ -52,7 +52,7 @@
 
 #include <vector>
 
-namespace Monero
+namespace Ryo
 {
 
 AddressBook::~AddressBook() {}
@@ -202,5 +202,3 @@ AddressBookImpl::~AddressBookImpl()
 }
 
 } // namespace
-
-namespace Bitmonero = Monero;

--- a/src/wallet/api/address_book.h
+++ b/src/wallet/api/address_book.h
@@ -47,7 +47,7 @@
 #include "wallet/api/wallet2_api.h"
 #include "wallet/wallet2.h"
 
-namespace Monero
+namespace Ryo
 {
 
 class WalletImpl;
@@ -81,5 +81,3 @@ class AddressBookImpl : public AddressBook
 	int m_errorCode;
 };
 }
-
-namespace Bitmonero = Monero;

--- a/src/wallet/api/pending_transaction.cpp
+++ b/src/wallet/api/pending_transaction.cpp
@@ -58,7 +58,7 @@
 
 using namespace std;
 
-namespace Monero
+namespace Ryo
 {
 
 PendingTransaction::~PendingTransaction() {}
@@ -225,5 +225,3 @@ std::vector<std::set<uint32_t>> PendingTransactionImpl::subaddrIndices() const
 	return result;
 }
 }
-
-namespace Bitmonero = Monero;

--- a/src/wallet/api/pending_transaction.h
+++ b/src/wallet/api/pending_transaction.h
@@ -50,7 +50,7 @@
 #include <string>
 #include <vector>
 
-namespace Monero
+namespace Ryo
 {
 
 class WalletImpl;
@@ -80,5 +80,3 @@ class PendingTransactionImpl : public PendingTransaction
 	std::vector<tools::wallet2::pending_tx> m_pending_tx;
 };
 }
-
-namespace Bitmonero = Monero;

--- a/src/wallet/api/subaddress.cpp
+++ b/src/wallet/api/subaddress.cpp
@@ -50,7 +50,7 @@
 
 #include <vector>
 
-namespace Monero
+namespace Ryo
 {
 
 Subaddress::~Subaddress() {}

--- a/src/wallet/api/subaddress.h
+++ b/src/wallet/api/subaddress.h
@@ -45,7 +45,7 @@
 #include "wallet/api/wallet2_api.h"
 #include "wallet/wallet2.h"
 
-namespace Monero
+namespace Ryo
 {
 
 class WalletImpl;

--- a/src/wallet/api/subaddress_account.cpp
+++ b/src/wallet/api/subaddress_account.cpp
@@ -50,7 +50,7 @@
 
 #include <vector>
 
-namespace Monero
+namespace Ryo
 {
 
 SubaddressAccount::~SubaddressAccount() {}

--- a/src/wallet/api/subaddress_account.h
+++ b/src/wallet/api/subaddress_account.h
@@ -45,7 +45,7 @@
 #include "wallet/api/wallet2_api.h"
 #include "wallet/wallet2.h"
 
-namespace Monero
+namespace Ryo
 {
 
 class WalletImpl;

--- a/src/wallet/api/transaction_history.cpp
+++ b/src/wallet/api/transaction_history.cpp
@@ -56,7 +56,7 @@
 
 using namespace epee;
 
-namespace Monero
+namespace Ryo
 {
 
 TransactionHistory::~TransactionHistory() {}
@@ -257,5 +257,3 @@ void TransactionHistoryImpl::refresh()
 }
 
 } // namespace
-
-namespace Bitmonero = Monero;

--- a/src/wallet/api/transaction_history.h
+++ b/src/wallet/api/transaction_history.h
@@ -47,7 +47,7 @@
 #include "wallet/api/wallet2_api.h"
 #include <boost/thread/shared_mutex.hpp>
 
-namespace Monero
+namespace Ryo
 {
 
 class WalletImpl;
@@ -70,5 +70,3 @@ class TransactionHistoryImpl : public TransactionHistory
 	mutable boost::shared_mutex m_historyMutex;
 };
 }
-
-namespace Bitmonero = Monero;

--- a/src/wallet/api/transaction_info.cpp
+++ b/src/wallet/api/transaction_info.cpp
@@ -48,7 +48,7 @@
 
 using namespace std;
 
-namespace Monero
+namespace Ryo
 {
 
 TransactionInfo::~TransactionInfo() {}
@@ -141,5 +141,3 @@ uint64_t TransactionInfoImpl::unlockTime() const
 }
 
 } // namespace
-
-namespace Bitmonero = Monero;

--- a/src/wallet/api/transaction_info.h
+++ b/src/wallet/api/transaction_info.h
@@ -48,7 +48,7 @@
 #include <ctime>
 #include <string>
 
-namespace Monero
+namespace Ryo
 {
 
 class TransactionHistoryImpl;
@@ -99,5 +99,3 @@ class TransactionInfoImpl : public TransactionInfo
 };
 
 } // namespace
-
-namespace Bitmonero = Monero;

--- a/src/wallet/api/unsigned_transaction.cpp
+++ b/src/wallet/api/unsigned_transaction.cpp
@@ -58,7 +58,7 @@
 
 using namespace std;
 
-namespace Monero
+namespace Ryo
 {
 
 UnsignedTransaction::~UnsignedTransaction() {}
@@ -344,5 +344,3 @@ uint64_t UnsignedTransactionImpl::minMixinCount() const
 }
 
 } // namespace
-
-namespace Bitmonero = Monero;

--- a/src/wallet/api/unsigned_transaction.h
+++ b/src/wallet/api/unsigned_transaction.h
@@ -50,7 +50,7 @@
 #include <string>
 #include <vector>
 
-namespace Monero
+namespace Ryo
 {
 
 class WalletImpl;
@@ -86,5 +86,3 @@ class UnsignedTransactionImpl : public UnsignedTransaction
 	std::string m_confirmationMessage;
 };
 }
-
-namespace Bitmonero = Monero;

--- a/src/wallet/api/utils.cpp
+++ b/src/wallet/api/utils.cpp
@@ -49,7 +49,7 @@
 
 using namespace std;
 
-namespace Monero
+namespace Ryo
 {
 namespace Utils
 {
@@ -74,5 +74,3 @@ void onStartup()
 }
 
 } // namespace
-
-namespace Bitmonero = Monero;

--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -71,7 +71,7 @@ using namespace cryptonote;
 //#undef RYO_DEFAULT_LOG_CATEGORY
 //#define RYO_DEFAULT_LOG_CATEGORY "WalletAPI"
 
-namespace Monero
+namespace Ryo
 {
 
 namespace
@@ -88,7 +88,7 @@ static const int DEFAULT_CONNECTION_TIMEOUT_MILLIS = 1000 * 30;
 std::string get_default_ringdb_path()
 {
 	boost::filesystem::path dir = tools::get_default_data_dir();
-	// remove .bitmonero, replace with .shared-ringdb
+	// remove .ryo, replace with .shared-ringdb
 	dir = dir.remove_filename();
 	dir /= ".shared-ringdb";
 	return dir.string();
@@ -2203,5 +2203,3 @@ void WalletImpl::keyReuseMitigation2(bool mitigation)
 }
 
 } // namespace
-
-namespace Bitmonero = Monero;

--- a/src/wallet/api/wallet.h
+++ b/src/wallet/api/wallet.h
@@ -55,7 +55,7 @@
 #include <boost/thread/thread.hpp>
 #include <string>
 
-namespace Monero
+namespace Ryo
 {
 class TransactionHistoryImpl;
 class PendingTransactionImpl;
@@ -239,7 +239,5 @@ class WalletImpl : public Wallet
 };
 
 } // namespace
-
-namespace Bitmonero = Monero;
 
 #endif

--- a/src/wallet/api/wallet2_api.h
+++ b/src/wallet/api/wallet2_api.h
@@ -54,7 +54,7 @@
 #include <vector>
 
 //  Public interface for libwallet library
-namespace Monero
+namespace Ryo
 {
 
 enum NetworkType : uint8_t
@@ -1038,5 +1038,3 @@ struct WalletManagerFactory
 	static void setLogCategories(const std::string &categories);
 };
 }
-
-namespace Bitmonero = Monero;

--- a/src/wallet/api/wallet_manager.cpp
+++ b/src/wallet/api/wallet_manager.cpp
@@ -63,7 +63,7 @@ namespace epee
 unsigned int g_test_dbg_lock_sleep = 0;
 }
 
-namespace Monero
+namespace Ryo
 {
 
 Wallet *WalletManagerImpl::createWallet(const std::string &path, const std::string &password,
@@ -376,5 +376,3 @@ void WalletManagerFactory::setLogCategories(const std::string &categories)
 	mlog_set_log(categories.c_str());
 }
 }
-
-namespace Bitmonero = Monero;

--- a/src/wallet/api/wallet_manager.h
+++ b/src/wallet/api/wallet_manager.h
@@ -48,7 +48,7 @@
 #include "wallet/api/wallet2_api.h"
 #include <string>
 
-namespace Monero
+namespace Ryo
 {
 
 class WalletManagerImpl : public WalletManager
@@ -106,5 +106,3 @@ class WalletManagerImpl : public WalletManager
 };
 
 } // namespace
-
-namespace Bitmonero = Monero;

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -141,7 +141,7 @@ namespace
 std::string get_default_ringdb_path()
 {
 	boost::filesystem::path dir = tools::get_default_data_dir();
-	// remove .bitmonero, replace with .shared-ringdb
+	// remove .ryo, replace with .shared-ringdb
 	dir = dir.remove_filename();
 	dir /= ".shared-ringdb";
 	return dir.string();


### PR DESCRIPTION
This PR fixes `make debug` compile issues.

- remove unused namespace creation `Bitmonero` in the global scope
- rename `Monero` namespace to `Ryo`