### PR TITLE
fix illegal memory access

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -798,7 +798,7 @@ difficulty_type Blockchain::get_difficulty_for_next_block()
 	//    then when the next block difficulty is queried, push the latest height data and
 	//    pop the oldest one from the list. This only requires 1x read per height instead
 	//    of doing 735 (DIFFICULTY_BLOCKS_COUNT).
-	if(m_timestamps_and_difficulties_height != 0 && ((height - m_timestamps_and_difficulties_height) == 1))
+	if(m_timestamps_and_difficulties_height != 0 && ((height - m_timestamps_and_difficulties_height) == 1) && timestamps.size() >= block_count && m_difficulties.size() >= block_count)
 	{
 		uint64_t index = height - 1;
 		m_timestamps.push_back(m_db->get_block_timestamp(index));


### PR DESCRIPTION
If the network fork from difficulty algorithm v2 to v3 the timestamp array is smaller than required in the difficulty algorithm. This result in an illegal memmory access.