### PR TITLE
add new difficulty algorithm

### DIFF
--- a/src/cryptonote_basic/difficulty.h
+++ b/src/cryptonote_basic/difficulty.h
@@ -71,4 +71,5 @@ bool check_hash(const crypto::hash &hash, difficulty_type difficulty);
 difficulty_type next_difficulty_v1(std::vector<std::uint64_t> timestamps, std::vector<difficulty_type> cumulative_difficulties, size_t target_seconds);
 difficulty_type next_difficulty_v2(std::vector<std::uint64_t> timestamps, std::vector<difficulty_type> cumulative_difficulties, size_t target_seconds);
 difficulty_type next_difficulty_v3(const std::vector<std::uint64_t> &timestamps, const std::vector<difficulty_type> &cumulative_difficulties);
+difficulty_type next_difficulty_v4(std::vector<std::uint64_t> timestamps, std::vector<difficulty_type> cumulative_difficulties);
 }

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -166,7 +166,8 @@ enum hard_fork_feature
 	FORK_FIXED_FEE,
 	FORK_NO_TIMED_LOCK,
 	FORK_NEED_V3_TXES,
-	FORK_BULLETPROOFS
+	FORK_BULLETPROOFS,
+	FORK_V4_DIFFICULTY
 };
 
 struct hardfork_conf
@@ -185,7 +186,8 @@ static constexpr hardfork_conf FORK_CONFIG[] = {
 	{FORK_FIXED_FEE, 4, 4, 1},
 	{FORK_NO_TIMED_LOCK, 4, 4, 1},
 	{FORK_NEED_V3_TXES, 4, 4, 1},
-	{FORK_BULLETPROOFS, hardfork_conf::FORK_ID_DISABLED, hardfork_conf::FORK_ID_DISABLED, 1}};
+	{FORK_BULLETPROOFS, hardfork_conf::FORK_ID_DISABLED, hardfork_conf::FORK_ID_DISABLED, 1},
+	{FORK_V3_DIFFICULTY, hardfork_conf::FORK_ID_DISABLED, 5, 1}};
 
 struct common_config
 {
@@ -214,6 +216,14 @@ struct common_config
 	static constexpr uint64_t DIFFICULTY_BLOCKS_COUNT_V3 = DIFFICULTY_WINDOW_V3;
 	static constexpr uint64_t BLOCKCHAIN_TIMESTAMP_CHECK_WINDOW_V3 = 11;
 	static constexpr uint64_t BLOCK_FUTURE_TIME_LIMIT_V3 = DIFFICULTY_TARGET * 3;
+
+	/////////////// V4 difficulty constants
+	// number of block those will be erased to reduce periodic time step attacks
+	static constexpr uint64_t DIFFICULTY_HOLES_V4 = 10;
+	static constexpr uint64_t DIFFICULTY_WINDOW_V4 = DIFFICULTY_WINDOW_V3;
+	static constexpr uint64_t DIFFICULTY_BLOCKS_COUNT_V4 = DIFFICULTY_WINDOW_V4 + DIFFICULTY_HOLES_V4;
+	static constexpr uint64_t BLOCKCHAIN_TIMESTAMP_CHECK_WINDOW_V4 = BLOCKCHAIN_TIMESTAMP_CHECK_WINDOW_V3;
+	static constexpr uint64_t BLOCK_FUTURE_TIME_LIMIT_V4 = BLOCK_FUTURE_TIME_LIMIT_V3;
 
 	static constexpr uint64_t CRYPTONOTE_BLOCK_GRANTED_FULL_REWARD_ZONE = 240 * 1024; // 240 kB
 	static constexpr uint64_t BLOCK_SIZE_GROWTH_FAVORED_ZONE = CRYPTONOTE_BLOCK_GRANTED_FULL_REWARD_ZONE * 4;

--- a/tests/core_tests/block_validation.cpp
+++ b/tests/core_tests/block_validation.cpp
@@ -104,7 +104,7 @@ bool gen_block_big_minor_version::generate(std::vector<test_event_entry> &events
 bool gen_block_ts_not_checked::generate(std::vector<test_event_entry> &events) const
 {
 	BLOCK_VALIDATION_INIT_GENERATE();
-	REWIND_BLOCKS_N(events, blk_0r, blk_0, miner_account, common_config::BLOCKCHAIN_TIMESTAMP_CHECK_WINDOW_V3 - 2);
+	REWIND_BLOCKS_N(events, blk_0r, blk_0, miner_account, common_config::BLOCKCHAIN_TIMESTAMP_CHECK_WINDOW_V4 - 2);
 
 	block blk_1;
 	generator.construct_block_manually(blk_1, blk_0r, miner_account, test_generator::bf_timestamp, 0, 0, blk_0.timestamp - 60 * 60);
@@ -118,9 +118,9 @@ bool gen_block_ts_not_checked::generate(std::vector<test_event_entry> &events) c
 bool gen_block_ts_in_past::generate(std::vector<test_event_entry> &events) const
 {
 	BLOCK_VALIDATION_INIT_GENERATE();
-	REWIND_BLOCKS_N(events, blk_0r, blk_0, miner_account, common_config::BLOCKCHAIN_TIMESTAMP_CHECK_WINDOW_V3 - 1);
+	REWIND_BLOCKS_N(events, blk_0r, blk_0, miner_account, common_config::BLOCKCHAIN_TIMESTAMP_CHECK_WINDOW_V4 - 1);
 
-	uint64_t ts_below_median = boost::get<block>(events[common_config::BLOCKCHAIN_TIMESTAMP_CHECK_WINDOW_V3 / 2 - 1]).timestamp;
+	uint64_t ts_below_median = boost::get<block>(events[common_config::BLOCKCHAIN_TIMESTAMP_CHECK_WINDOW_V4 / 2 - 1]).timestamp;
 	block blk_1;
 	generator.construct_block_manually(blk_1, blk_0r, miner_account, test_generator::bf_timestamp, 0, 0, ts_below_median);
 	events.push_back(blk_1);
@@ -135,7 +135,7 @@ bool gen_block_ts_in_future::generate(std::vector<test_event_entry> &events) con
 	BLOCK_VALIDATION_INIT_GENERATE();
 
 	block blk_1;
-	generator.construct_block_manually(blk_1, blk_0, miner_account, test_generator::bf_timestamp, 0, 0, time(NULL) + 60 * 60 + common_config::BLOCK_FUTURE_TIME_LIMIT_V3);
+	generator.construct_block_manually(blk_1, blk_0, miner_account, test_generator::bf_timestamp, 0, 0, time(NULL) + 60 * 60 + common_config::BLOCK_FUTURE_TIME_LIMIT_V4);
 	events.push_back(blk_1);
 
 	DO_CALLBACK(events, "check_block_purged");

--- a/tests/core_tests/block_validation.h
+++ b/tests/core_tests/block_validation.h
@@ -89,12 +89,12 @@ struct gen_block_big_minor_version : public gen_block_accepted_base<2>
 	bool generate(std::vector<test_event_entry> &events) const;
 };
 
-struct gen_block_ts_not_checked : public gen_block_accepted_base<cryptonote::common_config::BLOCKCHAIN_TIMESTAMP_CHECK_WINDOW_V3>
+struct gen_block_ts_not_checked : public gen_block_accepted_base<cryptonote::common_config::BLOCKCHAIN_TIMESTAMP_CHECK_WINDOW_V4>
 {
 	bool generate(std::vector<test_event_entry> &events) const;
 };
 
-struct gen_block_ts_in_past : public gen_block_verification_base<cryptonote::common_config::BLOCKCHAIN_TIMESTAMP_CHECK_WINDOW_V3>
+struct gen_block_ts_in_past : public gen_block_verification_base<cryptonote::common_config::BLOCKCHAIN_TIMESTAMP_CHECK_WINDOW_V4>
 {
 	bool generate(std::vector<test_event_entry> &events) const;
 };


### PR DESCRIPTION
- add testnet hardfork to block version 5
- add new difficulty algorithm

The algorithm I derived from the difficulty algorithm v3.
By removing a few blocks from the timestamp vector the possibility of an attack where
the timestamps are manipulated that the differens alternate between negative and positive
can be reduced.