### PR TITLE
make Poisson check stricter

### DIFF
--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -190,8 +190,8 @@ static constexpr hardfork_conf FORK_CONFIG[] = {
 struct common_config
 {
 	static constexpr uint64_t POISSON_CHECK_TRIGGER = 10;  // Reorg size that triggers poisson timestamp check
-	static constexpr uint64_t POISSON_CHECK_DEPTH = 150;   // Main-chain depth of the poisson check. The attacker will have to tamper 50% of those blocks
-	static constexpr double POISSON_LOG_P_REJECT = -100.0; // Reject reorg if the probablity that the timestamps are genuine is below e^x, -100 = 10^-44
+	static constexpr uint64_t POISSON_CHECK_DEPTH = 60;   // Main-chain depth of the poisson check. The attacker will have to tamper 50% of those blocks
+	static constexpr double POISSON_LOG_P_REJECT = -75.0; // Reject reorg if the probablity that the timestamps are genuine is below e^x, -75 = 10^-33
 
 	static constexpr uint64_t DIFFICULTY_TARGET = 240; // 4 minutes
 

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -891,7 +891,7 @@ bool Blockchain::rollback_blockchain_switching(std::list<block> &original_chain,
 // lam     - lambda parameter - in our case, how many blocks, on average, you would expect to see in the interval
 // k       - k parameter - in our case, how many blocks we have actually seen
 //           !!! k must not be zero
-// return  - ln(p), my recommendation would be to reject ln(p) smaller than -100 (e^-100 = 3x10^-44)
+// return  - ln(p)
 double calc_poisson_ln(double lam, uint64_t k)
 {
 	double logx = -lam + k * log(lam);


### PR DESCRIPTION
Two conclusions from testing:

- Large check window is not an advantage.
- LOG_P can come up to -75.0