### PR TITLE
clang fixes

### DIFF
--- a/src/crypto/cn_slow_hash.hpp
+++ b/src/crypto/cn_slow_hash.hpp
@@ -64,7 +64,9 @@
 #if defined(__x86_64__) || defined(__i386__) || defined(_M_X86) || defined(_M_X64)
 #ifdef __GNUC__
 #include <x86intrin.h>
-#pragma GCC target("aes")
+#ifndef __clang__
+#	pragma GCC target("aes")
+#endif
 #if !defined(HAS_WIN_INTRIN_API)
 #include <cpuid.h>
 #endif // !defined(HAS_WIN_INTRIN_API)

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -948,7 +948,7 @@ bool Blockchain::switch_to_alternative_blockchain(std::list<blocks_ext_by_hash::
 		LOG_PRINT_L1("Poisson check triggered by reorg size of " << alt_chain_size);
 
 		uint64_t failed_checks = 0, i = 1;
-		constexpr crypto::hash zero_hash = {0};
+		constexpr crypto::hash zero_hash = {{0}};
 		for(; i <= common_config::POISSON_CHECK_DEPTH; i++)
 		{
 			// This means we reached the genesis block

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -1009,7 +1009,10 @@ class core : public i_miner_handler
 	} check_updates_level;
 
 	tools::download_async_handle m_update_download;
+// updates are currently disabled
+#if 0
 	size_t m_last_update_length;
+#endif
 	boost::mutex m_update_mutex;
 
 	bool m_fluffy_blocks_enabled;


### PR DESCRIPTION
It is currently not possible to compile ryo with clang.
All compiler issues withh be addressed with this PR.

- disable `#pragma GCC target("aes")` for clang (it is unknown)
- disable code not used variable
- fix initialize of an constexpr variable  