### PR TITLE
add travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,107 @@
+language: cpp
+sudo: false
+
+cache:
+  apt: true
+
+matrix:
+  include:
+    - os: linux
+      addons:
+        apt:
+          update: true
+          sources:
+            - sourceline: 'ppa:mhier/libboost-latest'
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-4.9
+            - boost1.67
+      env:
+         - COMPILER="CC=gcc-4.9 && CXX=g++-4.9"
+
+    - os: linux
+      addons:
+        apt:
+          update: true
+          sources:
+            - sourceline: 'ppa:mhier/libboost-latest'
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-5
+            - boost1.67
+      env:
+         - COMPILER="CC=gcc-5 && CXX=g++-5"
+
+    - os: linux
+      addons:
+        apt:
+          update: true
+          sources:
+            - sourceline: 'ppa:mhier/libboost-latest'
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-6
+            - boost1.67
+      env:
+        - COMPILER="CC=gcc-6 && CXX=g++-6"
+
+    - os: linux
+      addons:
+        apt:
+          update: true
+          sources:
+            - sourceline: 'ppa:mhier/libboost-latest'
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-7
+            - boost1.67
+      env:
+        - COMPILER="CC=gcc-7 && CXX=g++-7"
+
+    - os: linux
+      addons:
+        apt:
+          update: true
+          sources:
+            - sourceline: 'ppa:mhier/libboost-latest'
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.8
+          packages:
+            - clang-3.8
+            - boost1.67
+      env:
+        - COMPILER="CC=clang-3.8 && CXX=clang++-3.8"
+
+    - os: linux
+      addons:
+        apt:
+          update: true
+          sources:
+            - sourceline: 'ppa:mhier/libboost-latest'
+            - llvm-toolchain-trusty-5.0
+          packages:
+            - clang-5.0
+            - boost1.67
+      env:
+        - COMPILER="CC=clang-5.0 && CXX=clang++-5.0"
+
+install:
+  - if [ $TRAVIS_OS_NAME = linux ]; then
+      sudo add-apt-repository ppa:ondrej/php -y;
+      sudo apt-get update;
+      sudo apt-get install -y build-essential cmake pkg-config;
+      sudo apt-get install -y libssl-dev libzmq3-dev libunbound-dev;
+      sudo apt-get install -y --allow-unauthenticated libsodium-dev;
+      sudo apt-get install -y libminiupnpc-dev libunwind8-dev liblzma-dev libreadline6-dev;
+      sudo apt-get install -y libldns-dev;
+    fi
+
+script:
+  - eval "${COMPILER}"
+  - cd $HOME
+  - mkdir linux-x64-build
+  - cd linux-x64-build
+  - cmake -DCMAKE_INSTALL_PREFIX=$HOME/ryo-linux-x64-release -DARCH="x86-64" -DBUILD_64=ON -DCMAKE_BUILD_TYPE=Debug -DBUILD_TAG="linux-x64-release" $TRAVIS_BUILD_DIR
+  - make
+  - make install
+


### PR DESCRIPTION
add basic compile tests for gcc 4.9,5,6,7 and clang 3.8, 5


OSX and additional tests will be added in an separate follow up PR.