### PR TITLE
fix clang compile

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -123,6 +123,7 @@ endfunction ()
 
 include(Version)
 monero_add_library(version SOURCES ${CMAKE_BINARY_DIR}/version.cpp DEPENDS genversion)
+monero_add_library(ccnconfig SOURCES ${CMAKE_SOURCE_DIR}/src/cryptonote_config.cpp)
 
 add_subdirectory(common)
 add_subdirectory(crypto)

--- a/src/blockchain_utilities/CMakeLists.txt
+++ b/src/blockchain_utilities/CMakeLists.txt
@@ -118,6 +118,7 @@ target_link_libraries(blockchain_import
     blockchain_db
     p2p
     version
+    ccnconfig
     epee
     ${Boost_FILESYSTEM_LIBRARY}
     ${Boost_SYSTEM_LIBRARY}
@@ -145,6 +146,7 @@ target_link_libraries(blockchain_export
     blockchain_db
     p2p
     version
+    ccnconfig
     epee
     ${Boost_FILESYSTEM_LIBRARY}
     ${Boost_SYSTEM_LIBRARY}
@@ -168,6 +170,7 @@ target_link_libraries(blockchain_blackball
     blockchain_db
     p2p
     version
+    ccnconfig
     epee
     ${Boost_FILESYSTEM_LIBRARY}
     ${Boost_SYSTEM_LIBRARY}
@@ -191,6 +194,7 @@ target_link_libraries(blockchain_usage
     blockchain_db
     p2p
     version
+    ccnconfig
     epee
     ${Boost_FILESYSTEM_LIBRARY}
     ${Boost_SYSTEM_LIBRARY}

--- a/src/cryptonote_config.cpp
+++ b/src/cryptonote_config.cpp
@@ -1,0 +1,52 @@
+// Copyright (c) 2018, Ryo Currency Project
+//
+// Portions of this file are available under BSD-3 license. Please see ORIGINAL-LICENSE for details
+// All rights reserved.
+//
+// Authors and copyright holders give permission for following:
+//
+// 1. Redistribution and use in source and binary forms WITHOUT modification.
+//
+// 2. Modification of the source form for your own personal use.
+//
+// As long as the following conditions are met:
+//
+// 3. You must not distribute modified copies of the work to third parties. This includes
+//    posting the work online, or hosting copies of the modified work for download.
+//
+// 4. Any derivative version of this work is also covered by this license, including point 8.
+//
+// 5. Neither the name of the copyright holders nor the names of the authors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// 6. You agree that this licence is governed by and shall be construed in accordance
+//    with the laws of England and Wales.
+//
+// 7. You agree to submit all disputes arising out of or in connection with this licence
+//    to the exclusive jurisdiction of the Courts of England and Wales.
+//
+// Authors and copyright holders agree that:
+//
+// 8. This licence expires and the work covered by it is released into the
+//    public domain on 1st of February 2019
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "cryptonote_config.h"
+
+template struct cryptonote::config<cryptonote::MAINNET>;
+template struct cryptonote::config<cryptonote::TESTNET>;
+template struct cryptonote::config<cryptonote::STAGENET>;
+
+constexpr boost::uuids::uuid cryptonote::config<cryptonote::MAINNET>::NETWORK_ID;
+constexpr boost::uuids::uuid cryptonote::config<cryptonote::TESTNET>::NETWORK_ID;
+constexpr boost::uuids::uuid cryptonote::config<cryptonote::STAGENET>::NETWORK_ID;

--- a/src/daemon/CMakeLists.txt
+++ b/src/daemon/CMakeLists.txt
@@ -111,6 +111,7 @@ target_link_libraries(daemon
     epee
     ${EPEE_READLINE}
     version
+    ccnconfig
     ${Boost_CHRONO_LIBRARY}
     ${Boost_FILESYSTEM_LIBRARY}
     ${Boost_PROGRAM_OPTIONS_LIBRARY}

--- a/src/mnemonics/electrum-words.cpp
+++ b/src/mnemonics/electrum-words.cpp
@@ -146,7 +146,7 @@ bool find_seed_language(const std::vector<std::string> &seed, Language::Base **l
 		Language::Base *inst;
 		size_t score;
 
-		inline bool operator<(const sort_pair &oth) { return score < oth.score; }
+		inline bool operator<(const sort_pair &oth) const { return score < oth.score; }
 	};
 
 	// If there's a new language added, add an instance of it here.

--- a/src/simplewallet/CMakeLists.txt
+++ b/src/simplewallet/CMakeLists.txt
@@ -67,6 +67,7 @@ target_link_libraries(simplewallet
     epee
     ${EPEE_READLINE}
     version
+    ccnconfig
     ${Boost_CHRONO_LIBRARY}
     ${Boost_PROGRAM_OPTIONS_LIBRARY}
     ${Boost_FILESYSTEM_LIBRARY}

--- a/src/wallet/CMakeLists.txt
+++ b/src/wallet/CMakeLists.txt
@@ -107,6 +107,7 @@ target_link_libraries(wallet_rpc_server
     cncrypto
     common
     version
+    ccnconfig
     ${Boost_CHRONO_LIBRARY}
     ${Boost_PROGRAM_OPTIONS_LIBRARY}
     ${Boost_FILESYSTEM_LIBRARY}

--- a/tests/core_proxy/CMakeLists.txt
+++ b/tests/core_proxy/CMakeLists.txt
@@ -41,6 +41,7 @@ target_link_libraries(core_proxy
     cryptonote_protocol
     p2p
     version
+    ccnconfig
     epee
     ${CMAKE_THREAD_LIBS_INIT}
     ${EXTRA_LIBRARIES})

--- a/tests/core_tests/CMakeLists.txt
+++ b/tests/core_tests/CMakeLists.txt
@@ -69,6 +69,7 @@ target_link_libraries(core_tests
     cryptonote_core
     p2p
     version
+    ccnconfig
     epee
     device
     ${CMAKE_THREAD_LIBS_INIT}

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -85,6 +85,7 @@ target_link_libraries(unit_tests
     wallet
     p2p
     version
+    ccnconfig
     epee
     ${Boost_CHRONO_LIBRARY}
     ${Boost_THREAD_LIBRARY}


### PR DESCRIPTION
- clang need the comparison operator defined as const if the object is const.
- fix
  ```
  Undefined symbols for architecture x86_64:
   "cryptonote::config<(cryptonote::network_type)0>::NETWORK_ID", referenced from:
     nodetool::node_server<cryptonote::t_cryptonote_protocol_handler<cryptonote::core> 
  >::init(boost::program_options::variables_map const&) in librpc.a(instanciations.cpp.o)
  ```