### PR TITLE
fix travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: cpp
-sudo: false
+sudo: required
 
 cache:
   apt: true


### PR DESCRIPTION
allow usage of `sudo` to install new software packages