### PR TITLE
 fix `get_approximate_blockchain_height`

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -8291,10 +8291,10 @@ uint64_t wallet2::get_daemon_blockchain_target_height(string &err)
 uint64_t wallet2::get_approximate_blockchain_height() const
 {
 	if (m_nettype == TESTNET) return 0;
-	// time of v3 fork
-	const time_t fork_time = 1522881180;
-	// v3 fork block
-	const uint64_t fork_block = 116520;
+	// time of v4 fork
+	const time_t fork_time = 1530990884;
+	// v4 fork block
+	const uint64_t fork_block = 150000;
 	
 	// Calculated blockchain height
 	time_t current_time = time(NULL);

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -8290,16 +8290,17 @@ uint64_t wallet2::get_daemon_blockchain_target_height(string &err)
 
 uint64_t wallet2::get_approximate_blockchain_height() const
 {
-	// time of v2 fork
-	const time_t fork_time = m_nettype == TESTNET ? 1448285909 : m_nettype == STAGENET ? (time_t)-1 /*TODO*/ : 1458748658;
-	// v2 fork block
-	const uint64_t fork_block = m_nettype == TESTNET ? 624634 : m_nettype == STAGENET ? (uint64_t)-1 /*TODO*/ : 1009827;
+	if (m_nettype == TESTNET) return 0;
+	// time of v3 fork
+	const time_t fork_time = 1522881180;
+	// v3 fork block
+	const uint64_t fork_block = 116520;
+	
 	// Calculated blockchain height
-	uint64_t approx_blockchain_height = fork_block + uint64_t(time(NULL) - fork_time) / common_config::DIFFICULTY_TARGET;
-	// testnet got some huge rollbacks, so the estimation is way off
-	static const uint64_t approximate_testnet_rolled_back_blocks = 148540;
-	if(m_nettype == TESTNET && approx_blockchain_height > approximate_testnet_rolled_back_blocks)
-		approx_blockchain_height -= approximate_testnet_rolled_back_blocks;
+	time_t current_time = time(NULL);
+	if (current_time <= 0)
+		current_time = fork_time;
+	uint64_t approx_blockchain_height = fork_block + (current_time - fork_time) / common_config::DIFFICULTY_TARGET;
 	LOG_PRINT_L2("Calculated blockchain height: " << approx_blockchain_height);
 	return approx_blockchain_height;
 }


### PR DESCRIPTION
- Change method back to sumokoin code, this function was accidental changed during the code base switch.
- Use latest fork v4 as base to approximate the blockchain height.