### PR TITLE
fix a bug in rescan_bc

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -3097,6 +3097,7 @@ crypto::secret_key_16 wallet2::generate_new(const std::string &wallet_, const ep
 	else
 	{
 		m_account.recover(*seed, extra);
+		recover = true;
 	}
 
 	m_account_public_address = m_account.get_keys().m_account_address;


### PR DESCRIPTION
Thanks to @psychocrypt for finding it.

I left out `recover` flag. Unless it is triggered the wallet will optimise as if it was just created scanning only couple 1000 blocks, causing it to miss inputs.