### PR TITLE
simplewallet: `rescan_bc` add optional argument

### DIFF
--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -204,7 +204,16 @@ class simple_wallet : public tools::i_wallet2_callback
 	bool show_transfers(const std::vector<std::string> &args);
 	bool unspent_outputs(const std::vector<std::string> &args);
 	bool rescan_blockchain(const std::vector<std::string> &args);
-	bool refresh_main(uint64_t start_height, bool reset = false, bool is_init = false);
+	/** refresh the wallet
+	 *
+	 * Rebuild the internal block structure and recalculate the wallet amount.
+	 *
+	 * @param start_height the block height where the amount received payments is started
+	 * @param reset if true the internal data structures will be reset and rebuild from scratch
+	 * @param is_init prints a account overview e.g. the balance and unlocked balance
+	 * @param use_optimized_height if true the refresh process used a internal optimized start height and skip older blocks
+	 */
+	bool refresh_main(uint64_t start_height, bool reset = false, bool is_init = false, bool use_optimized_height = true);
 	bool set_tx_note(const std::vector<std::string> &args);
 	bool get_tx_note(const std::vector<std::string> &args);
 	bool set_description(const std::vector<std::string> &args);


### PR DESCRIPTION
Add an optional argument to `rescan_bc` to specialize the height to start the rescan.
The default if no argument is equal to the behavior before and start syncing from an optimized height.

- fix documentation of `refresh`
- extend `rescan_bc` with optional argument
- if a start height is given for: `rescan_bc` and `refresh` a non optimized refresh without skipping blocks before the wallet creation is performed

- wallet2: `m_explicit_refresh_from_block_height` was never used in the code before.
  - `m_explicit_refresh_from_block_height`
    - enabling that transactions in `process_new_blockchain_entry` are ignored if they are older than the wallet.
    - enabling that `m_refresh_from_block_height` is used to optimize the start height