### PR TITLE
fix readline support for docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,6 +86,18 @@ RUN git clone https://github.com/jedisct1/libsodium.git -b ${SODIUM_VERSION} \
     && make check \
     && make install
 
+# ncurses 
+# Needed for readline find module in cmake. Why is it not documented?
+# WARNING: ncurses 6.1 is not working correctly with RYO so we stay with the common 5.X
+ARG NCURSES_VERSION=5.9
+ARG NCURSES_HASH=9046298fb440324c9d4135ecea7879ffed8546dd1b58e59430ea07a4633f563b
+RUN curl -s -O ftp://ftp.gnu.org/pub/gnu/ncurses/ncurses-${NCURSES_VERSION}.tar.gz \
+    && tar -xvf ncurses-${NCURSES_VERSION}.tar.gz \
+    && echo "${NCURSES_HASH} ncurses-${NCURSES_VERSION}.tar.gz" | sha256sum -c \
+    && cd ncurses-${NCURSES_VERSION} \
+    && CFLAGS="-fPIC" CXXFLAGS="-fPIC -P" CPPFLAGS="-P" ./configure \
+    && make install
+
 WORKDIR /src
 COPY . .
 


### PR DESCRIPTION
The cmake find script for readline depends on ncurses.
This is not documented and the result is that RYO build always without readline support.
source: https://github.com/bro/cmake/blob/9a9bbd29413ed6eba645e09628ba8eed8232603f/FindReadline.cmake#L34
readline is to support e.g. the arrow usage in the cli wallet and the daemon.

- add build recipe for ncureses to the docker container