### PR TITLE
fix tests for block reward

### DIFF
--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -67,7 +67,6 @@
 #define FINAL_SUBSIDY ((uint64_t)4000000000)			  // 4 * pow(10, 9)
 #define GENESIS_BLOCK_REWARD ((uint64_t)8800000000000000) // ~10% dev premine, now  mostly burned
 #define EMISSION_SPEED_FACTOR_PER_MINUTE (20)
-#define FINAL_SUBSIDY_PER_MINUTE ((uint64_t)300000000000) // 3 * pow(10, 11)
 
 #define CRYPTONOTE_REWARD_BLOCKS_WINDOW 60
 


### PR DESCRIPTION
- fix block reward tests
- remove `FINAL_SUBSIDY_PER_MINUTE` (left over from monero and itherefore not used)
- extent macro `TEST_ALREADY_GENERATED_COINS` with the block-height for testing