### PR TITLE
fix compile with boost local

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -54,7 +54,8 @@ set(common_sources
   password.cpp
   perf_timer.cpp
   threadpool.cpp
-  updates.cpp)
+  updates.cpp
+  boost_locale.cpp)
 
 if (STACK_TRACE)
   list(APPEND common_sources stack_trace.cpp)
@@ -83,7 +84,8 @@ set(common_private_headers
   perf_timer.h
   stack_trace.h
   threadpool.h
-  updates.h)
+  updates.h
+  boost_locale.hpp)
 
 ryo_private_headers(common
   ${common_private_headers})
@@ -105,7 +107,9 @@ target_link_libraries(common
     ${Boost_REGEX_LIBRARY}
     ${Boost_CHRONO_LIBRARY}
   PRIVATE
+    ${Boost_LOCALE_LIBRARY}
     ${OPENSSL_LIBRARIES}
+    ${ICU_LIBRARIES}
     ${EXTRA_LIBRARIES})
 
 #monero_install_headers(common

--- a/src/common/boost_locale.cpp
+++ b/src/common/boost_locale.cpp
@@ -41,8 +41,19 @@
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#pragma once
 
+#include "boost_locale.hpp"
 
-void boost_locale_init();
+#include <boost/locale.hpp>
+
+void boost_locale_init()
+{
+	static bool init_done = false;
+	if(init_done) return;
+
+	boost::locale::generator gen;
+	std::locale loc = gen.generate("");
+	std::locale::global(loc);
+	init_done = true;
+}
 

--- a/src/mnemonics/CMakeLists.txt
+++ b/src/mnemonics/CMakeLists.txt
@@ -76,4 +76,7 @@ target_link_libraries(mnemonics
     easylogging
     ${Boost_SYSTEM_LIBRARY}
   PRIVATE
+    common
+    ${Boost_LOCALE_LIBRARY}
+    ${ICU_LIBRARIES}
     ${EXTRA_LIBRARIES})

--- a/src/mnemonics/electrum-words.cpp
+++ b/src/mnemonics/electrum-words.cpp
@@ -58,6 +58,7 @@
 #include <boost/algorithm/string/join.hpp>
 #include <boost/crc.hpp>
 #include <boost/filesystem.hpp>
+#include <boost/locale.hpp>
 #include "common/boost_locale.hpp"
 #include <cassert>
 #include <cstdint>

--- a/src/simplewallet/CMakeLists.txt
+++ b/src/simplewallet/CMakeLists.txt
@@ -73,7 +73,6 @@ target_link_libraries(simplewallet
     ${Boost_FILESYSTEM_LIBRARY}
     ${ICU_LIBRARIES}
     ${Boost_THREAD_LIBRARY}
-    ${Boost_LOCALE_LIBRARY}
     ${CMAKE_THREAD_LIBS_INIT}
     ${GNU_READLINE_LIBRARY}
     ${EXTRA_LIBRARIES})

--- a/src/wallet/CMakeLists.txt
+++ b/src/wallet/CMakeLists.txt
@@ -79,7 +79,6 @@ target_link_libraries(wallet
     ${Boost_FILESYSTEM_LIBRARY}
     ${Boost_SYSTEM_LIBRARY}
     ${Boost_THREAD_LIBRARY}
-    ${Boost_LOCALE_LIBRARY}
     ${Boost_REGEX_LIBRARY}
   PRIVATE
     ${EXTRA_LIBRARIES})
@@ -113,7 +112,6 @@ target_link_libraries(wallet_rpc_server
     ${Boost_PROGRAM_OPTIONS_LIBRARY}
     ${Boost_FILESYSTEM_LIBRARY}
     ${Boost_THREAD_LIBRARY}
-    ${Boost_LOCALE_LIBRARY}
     ${CMAKE_THREAD_LIBS_INIT}
     ${EXTRA_LIBRARIES})
 set_property(TARGET wallet_rpc_server


### PR DESCRIPTION
Since #82 the windows compile is broken. There are many linker issue.

- separate `boost_local.hpp` into `hpp` and `cpp` to avoid that the library common is moving the boost locale dependency into all targets
- link icu mnemonics library
- remove boost locale library from all targets those have no dependency to this library