### PR TITLE
Monero caching bug

### DIFF
--- a/src/cryptonote_basic/hardfork.cpp
+++ b/src/cryptonote_basic/hardfork.cpp
@@ -413,14 +413,14 @@ uint8_t HardFork::get_ideal_version(uint64_t height) const
 	return original_version;
 }
 
-uint64_t HardFork::get_earliest_ideal_height_for_version(uint8_t version) const
+uint64_t HardFork::get_height_for_version(uint8_t version) const
 {
-	for(unsigned int n = heights.size() - 1; n > 0; --n)
+	for(const Params& fork : heights)
 	{
-		if(heights[n].version <= version)
-			return heights[n].height;
+		if(fork.version == version)
+			return fork.height;
 	}
-	return 0;
+	return uint64_t(-1);
 }
 
 uint8_t HardFork::get_next_version() const
@@ -449,7 +449,7 @@ bool HardFork::get_voting_info(uint8_t version, uint32_t &window, uint32_t &vote
 		votes += last_versions[n];
 	threshold = (window * heights[current_fork_index].threshold + 99) / 100;
 	//assert((votes >= threshold) == enabled);
-	earliest_height = get_earliest_ideal_height_for_version(version);
+	earliest_height = get_height_for_version(version);
 	voting = heights.back().version;
 	return enabled;
 }

--- a/src/cryptonote_basic/hardfork.h
+++ b/src/cryptonote_basic/hardfork.h
@@ -213,9 +213,10 @@ class HardFork
 	uint8_t get_current_version_num() const;
 
 	/**
-     * @brief returns the earliest block a given version may activate
+     * @brief returns the earliest block a known version may activate
+     * @return height or uint64_t(-1) if the version is not known
      */
-	uint64_t get_earliest_ideal_height_for_version(uint8_t version) const;
+	uint64_t get_height_for_version(uint8_t version) const;
 
 	/**
      * @brief returns information about current voting state

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -759,7 +759,12 @@ class Blockchain
      */
 	uint8_t get_current_hard_fork_version_num() const { return m_hardfork->get_current_version_num(); }
 
-	bool check_hard_fork_feature(hard_fork_feature ft) const { return m_hardfork->get_current_version_num() >= get_fork_v(m_nettype, ft); }
+	bool check_hard_fork_feature(hard_fork_feature ft) const 
+	{
+		if(get_fork_v(m_nettype, ft) == hardfork_conf::FORK_ID_DISABLED)
+			return false;
+		return m_hardfork->get_current_version_num() >= get_fork_v(m_nettype, ft); 
+	}
 
 	/**
      * @brief returns the newest hardfork version known to the blockchain

--- a/src/wallet/node_rpc_proxy.cpp
+++ b/src/wallet/node_rpc_proxy.cpp
@@ -153,7 +153,7 @@ boost::optional<std::string> NodeRPCProxy::get_earliest_height(uint8_t version, 
 		CHECK_AND_ASSERT_MES(r, std::string(), "Failed to connect to daemon");
 		CHECK_AND_ASSERT_MES(resp_t.status != CORE_RPC_STATUS_BUSY, resp_t.status, "Failed to connect to daemon");
 		CHECK_AND_ASSERT_MES(resp_t.status == CORE_RPC_STATUS_OK, resp_t.status, "Failed to get hard fork status");
-		m_earliest_height[version] = resp_t.enabled ? resp_t.earliest_height : std::numeric_limits<uint64_t>::max();
+		m_earliest_height[version] = resp_t.earliest_height;
 	}
 
 	earliest_height = m_earliest_height[version];

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -7218,7 +7218,7 @@ bool wallet2::use_fork_rules(cryptonote::hard_fork_feature ft, int64_t early_blo
 	result = m_node_rpc_proxy.get_earliest_height(version, earliest_height);
 	throw_on_rpc_response_error(result, "get_hard_fork_info");
 
-	bool close_enough = height >= earliest_height - early_blocks && earliest_height != std::numeric_limits<uint64_t>::max(); // start using the rules that many blocks beforehand
+	bool close_enough = height >= earliest_height - early_blocks; // start using the rules that many blocks beforehand
 	if(close_enough)
 		LOG_PRINT_L2("Using v" << (unsigned)version << " rules");
 	else

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -7212,6 +7212,10 @@ void wallet2::get_hard_fork_info(uint8_t version, uint64_t &earliest_height) con
 bool wallet2::use_fork_rules(cryptonote::hard_fork_feature ft, int64_t early_blocks) const
 {
 	uint8_t version = cryptonote::get_fork_v(m_nettype, ft);
+
+	if(version == cryptonote::hardfork_conf::FORK_ID_DISABLED)
+		return false;
+
 	uint64_t height, earliest_height;
 	boost::optional<std::string> result = m_node_rpc_proxy.get_height(height);
 	throw_on_rpc_response_error(result, "get_info");


### PR DESCRIPTION
Somebody had a stunning idea of combining two states ( `earliest_height` and `enabled` ) into a single value and caching them together. The problem is while `earliest_height` doesn't change on the fork, `enabled` does. So if we make the call when `enabled` = `false` (aka before the fork), we will never apply the rules for that fork until the wallet is restarted and the cache clears.