### PR TITLE
fix wrong exit code for `--help`

### DIFF
--- a/src/blockchain_utilities/blockchain_blackball.cpp
+++ b/src/blockchain_utilities/blockchain_blackball.cpp
@@ -226,7 +226,7 @@ int main(int argc, char *argv[])
 	{
 		std::cout << "Ryo '" << RYO_RELEASE_NAME << "' (" << RYO_VERSION_FULL << ")" << ENDL << ENDL;
 		std::cout << desc_options << std::endl;
-		return 1;
+		return 0;
 	}
 
 	mlog_configure(mlog_get_default_log_path("ryo-blockchain-blackball.log"), true);

--- a/src/blockchain_utilities/blockchain_export.cpp
+++ b/src/blockchain_utilities/blockchain_export.cpp
@@ -112,7 +112,7 @@ int main(int argc, char *argv[])
 	{
 		std::cout << "Ryo '" << RYO_RELEASE_NAME << "' (" << RYO_VERSION_FULL << ")" << ENDL << ENDL;
 		std::cout << desc_options << std::endl;
-		return 1;
+		return 0;
 	}
 
 	mlog_configure(mlog_get_default_log_path("ryo-blockchain-export.log"), true);

--- a/src/blockchain_utilities/blockchain_import.cpp
+++ b/src/blockchain_utilities/blockchain_import.cpp
@@ -648,7 +648,7 @@ int main(int argc, char *argv[])
 	{
 		std::cout << "Ryo '" << RYO_RELEASE_NAME << "' (" << RYO_VERSION_FULL << ")" << ENDL << ENDL;
 		std::cout << desc_options << std::endl;
-		return 1;
+		return 0;
 	}
 
 	if(!opt_batch && !command_line::is_arg_defaulted(vm, arg_batch_size))

--- a/src/blockchain_utilities/blockchain_usage.cpp
+++ b/src/blockchain_utilities/blockchain_usage.cpp
@@ -150,7 +150,7 @@ int main(int argc, char *argv[])
 	{
 		std::cout << "Ryo '" << RYO_RELEASE_NAME << "' (" << RYO_VERSION_FULL << ")" << ENDL << ENDL;
 		std::cout << desc_options << std::endl;
-		return 1;
+		return 0;
 	}
 
 	mlog_configure(mlog_get_default_log_path("ryo-blockchain-usage.log"), true);

--- a/src/debug_utilities/cn_deserialize.cpp
+++ b/src/debug_utilities/cn_deserialize.cpp
@@ -116,7 +116,7 @@ int main(int argc, char *argv[])
 	{
 		std::cout << "Ryo '" << RYO_RELEASE_NAME << "' (" << RYO_VERSION_FULL << ")" << ENDL << ENDL;
 		std::cout << desc_options << std::endl;
-		return 1;
+		return 0;
 	}
 
 	log_level = command_line::get_arg(vm, arg_log_level);

--- a/src/gen_multisig/gen_multisig.cpp
+++ b/src/gen_multisig/gen_multisig.cpp
@@ -191,6 +191,7 @@ int main(int argc, char *argv[])
 	command_line::add_arg(desc_params, arg_stagenet);
 	command_line::add_arg(desc_params, arg_create_address_file);
 
+	int vm_error_code = 1;
 	const auto vm = wallet_args::main(
 		argc, argv,
 		"ryo-gen-multisig [(--testnet|--stagenet)] [--filename-base=<filename>] [--scheme=M/N] [--threshold=M] [--participants=N]",
@@ -198,9 +199,10 @@ int main(int argc, char *argv[])
 		desc_params,
 		boost::program_options::positional_options_description(),
 		[](const std::string &s, bool emphasis) { tools::scoped_message_writer(emphasis ? epee::console_color_white : epee::console_color_default, true) << s; },
-		"ryo-gen-multisig.log");
+		"ryo-gen-multisig.log",
+		vm_error_code);
 	if(!vm)
-		return 1;
+		return vm_error_code;
 
 	bool testnet, stagenet;
 	uint32_t threshold = 0, total = 0;

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -7605,6 +7605,7 @@ int main(int argc, char *argv[])
 	po::positional_options_description positional_options;
 	positional_options.add(arg_command.name, -1);
 
+	int vm_error_code = 1;
 	const auto vm = wallet_args::main(
 		argc, argv,
 		"ryo-wallet-cli [--wallet-file=<file>|--generate-new-wallet=<file>] [<COMMAND>]",
@@ -7612,11 +7613,12 @@ int main(int argc, char *argv[])
 		desc_params,
 		positional_options,
 		[](const std::string &s, bool emphasis) { tools::scoped_message_writer(emphasis ? epee::console_color_white : epee::console_color_default, true) << s; },
-		"ryo-wallet-cli.log");
+		"ryo-wallet-cli.log",
+		vm_error_code);
 
 	if(!vm)
 	{
-		return 1;
+		return vm_error_code;
 	}
 
 	cryptonote::simple_wallet w;

--- a/src/wallet/wallet_args.cpp
+++ b/src/wallet/wallet_args.cpp
@@ -112,6 +112,7 @@ boost::optional<boost::program_options::variables_map> main(
 	const boost::program_options::positional_options_description &positional_options,
 	const std::function<void(const std::string &, bool)> &print,
 	const char *default_log_name,
+	int &error_code,
 	bool log_to_console)
 
 {
@@ -120,6 +121,8 @@ boost::optional<boost::program_options::variables_map> main(
 #ifdef WIN32
 	_CrtSetDbgFlag(_CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF);
 #endif
+
+	error_code = 1;
 
 	const command_line::arg_descriptor<std::string> arg_log_level = {"log-level", "0-4 or categories", ""};
 	const command_line::arg_descriptor<std::size_t> arg_max_log_file_size = {"max-log-file-size", "Specify maximum log file size [B]", MAX_LOG_FILE_SIZE};
@@ -158,11 +161,13 @@ boost::optional<boost::program_options::variables_map> main(
 			Print(print) << wallet_args::tr("This is the command line ryo wallet. It needs to connect to a ryo daemon to work correctly.") << ENDL;
 			Print(print) << wallet_args::tr("Usage:") << ENDL << "  " << usage;
 			Print(print) << desc_all;
+			error_code = 0;
 			return false;
 		}
 		else if(command_line::get_arg(vm, command_line::arg_version))
 		{
 			Print(print) << "Ryo '" << RYO_RELEASE_NAME << "' (" << RYO_VERSION_FULL << ")";
+			error_code = 0;
 			return false;
 		}
 
@@ -183,6 +188,7 @@ boost::optional<boost::program_options::variables_map> main(
 		}
 
 		po::notify(vm);
+		error_code = 0;
 		return true;
 	});
 	if(!r)
@@ -215,6 +221,7 @@ boost::optional<boost::program_options::variables_map> main(
 
 	Print(print) << boost::format(wallet_args::tr("Logging to %s")) % log_path;
 
+	error_code = 0;
 	return {std::move(vm)};
 }
 }

--- a/src/wallet/wallet_args.h
+++ b/src/wallet/wallet_args.h
@@ -60,7 +60,8 @@ const char *tr(const char *str);
   concurrency. Log file and concurrency arguments are handled, along with basic
   global init for the wallet process.
 
-  \return The list of parsed options, iff there are no errors.*/
+  \param error_code error code of the parsing process: zero means no errors, else non zero
+  \return The list of parsed options, if there are no errors.*/
 boost::optional<boost::program_options::variables_map> main(
 	int argc, char **argv,
 	const char *const usage,
@@ -68,5 +69,5 @@ boost::optional<boost::program_options::variables_map> main(
 	boost::program_options::options_description desc_params,
 	const boost::program_options::positional_options_description &positional_options,
 	const std::function<void(const std::string &, bool)> &print,
-	const char *default_log_name, bool log_to_console = false);
+	const char *default_log_name, int &error_code, bool log_to_console = false);
 }

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -2922,6 +2922,7 @@ int main(int argc, char **argv)
 	command_line::add_arg(desc_params, arg_wallet_dir);
 	command_line::add_arg(desc_params, arg_prompt_for_password);
 
+	int vm_error_code = 1;
 	const auto vm = wallet_args::main(
 		argc, argv,
 		"ryo-wallet-rpc [--wallet-file=<file>|--generate-from-json=<file>|--wallet-dir=<directory>] [--rpc-bind-port=<port>]",
@@ -2930,10 +2931,11 @@ int main(int argc, char **argv)
 		po::positional_options_description(),
 		[](const std::string &s, bool emphasis) { epee::set_console_color(emphasis ? epee::console_color_white : epee::console_color_default, true); std::cout << s << std::endl; if (emphasis) epee::reset_console_color(); },
 		"ryo-wallet-rpc.log",
+		vm_error_code,
 		true);
 	if(!vm)
 	{
-		return 1;
+		return vm_error_code;
 	}
 
 	std::unique_ptr<tools::wallet2> wal;


### PR DESCRIPTION
If the user ask the app to show the help the most binaries currently returning the exit code `1`.
Asking for a the help message and get them showed without errors must be return the exit code zero because the user requested action is fulfilled.

- return exit code zero user request `-h/--help`
- return exit code zero if `--version` is requested and a valid cli option