### PR TITLE
Wallet fixes

### DIFF
--- a/src/crypto/crypto.cpp
+++ b/src/crypto/crypto.cpp
@@ -171,11 +171,13 @@ void generate_wallet_secret(secret_key_16 &wallet_secret)
 
 void generate_wallet_keys(public_key &pub, secret_key &sec, const secret_key_16 &wallet_secret, uint32_t key_variant)
 {
+#pragma pack(push, 1)
 	struct hash_secret
 	{
 		uint32_t variant;
 		scalar_16 secret;
 	};
+#pragma pack(pop)
 
 	tools::scrubbed<hash_secret> hs;
 	unwrap(hs).secret = unwrap(wallet_secret);

--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -110,9 +110,9 @@ class simple_wallet : public tools::i_wallet2_callback
 	std::pair<std::unique_ptr<tools::wallet2>, tools::password_container> make_new_wrapped(const boost::program_options::variables_map &vm, 
 																			const std::function<boost::optional<tools::password_container>(const char *, bool)> &password_prompter);
 	
-	bool new_wallet(const boost::program_options::variables_map &vm, std::string seed);
-	bool new_wallet(const boost::program_options::variables_map &vm, const crypto::secret_key_16 *seed = nullptr, uint8_t seed_extra = cryptonote::ACC_OPT_LONG_ADDRESS);
-	bool restore_legacy_wallet(const boost::program_options::variables_map &vm, const crypto::secret_key &seed_legacy);
+	bool new_wallet_from_seed(const boost::program_options::variables_map &vm, std::string seed);
+	bool new_wallet(const boost::program_options::variables_map &vm, const std::string& seed_lang, const crypto::secret_key_16 *seed = nullptr, uint8_t seed_extra = cryptonote::ACC_OPT_LONG_ADDRESS);
+	bool restore_legacy_wallet(const boost::program_options::variables_map &vm, const std::string& seed_lang, const crypto::secret_key &seed_legacy);
 
 	bool new_wallet(const boost::program_options::variables_map &vm, const cryptonote::account_public_address &address,
 					const boost::optional<crypto::secret_key> &spendkey, const crypto::secret_key &viewkey);


### PR DESCRIPTION
Three fixes rolled into one:

- Uninitialised access to `m_wallet` causing a crash
- Extra security for `hash_secret` to prevent padding from screwing up key generation (default, 4, is ok)
- Prompt user for the missing metadata if 12-word seed was used.