### PR TITLE
Windows Internationalization Fixes

### DIFF
--- a/src/wallet/CMakeLists.txt
+++ b/src/wallet/CMakeLists.txt
@@ -111,6 +111,8 @@ target_link_libraries(wallet_rpc_server
     ${Boost_CHRONO_LIBRARY}
     ${Boost_PROGRAM_OPTIONS_LIBRARY}
     ${Boost_FILESYSTEM_LIBRARY}
+    ${Boost_LOCALE_LIBRARY}
+    ${ICU_LIBRARIES}
     ${Boost_THREAD_LIBRARY}
     ${CMAKE_THREAD_LIBS_INIT}
     ${EXTRA_LIBRARIES})

--- a/src/wallet/wallet_args.cpp
+++ b/src/wallet/wallet_args.cpp
@@ -54,6 +54,7 @@
 
 #if defined(WIN32)
 #include <crtdbg.h>
+#include <boost/locale.hpp>
 #endif
 
 //#undef RYO_DEFAULT_LOG_CATEGORY
@@ -120,6 +121,9 @@ boost::optional<boost::program_options::variables_map> main(
 	namespace po = boost::program_options;
 #ifdef WIN32
 	_CrtSetDbgFlag(_CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF);
+	// Activate UTF-8 support for Boost filesystem classes on Windows
+	std::locale::global(boost::locale::generator().generate(""));
+	boost::filesystem::path::imbue(std::locale());
 #endif
 
 	error_code = 1;


### PR DESCRIPTION
Applies the same fix from simplewallet (https://github.com/ryo-currency/ryo-currency/blob/master/src/simplewallet/simplewallet.cpp#L7659) to the RPC. 

Fixes opening of wallet files with international characters in the filename.