### PR TITLE
 fix gcc8 compile under linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -96,6 +96,26 @@ matrix:
       env:
         - COMPILERS="CC=gcc-7 CXX=g++-7"
         - COMPILE=tests
+    - name: g++-8 daemon
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-8
+      env:
+        - COMPILERS="CC=gcc-8 CXX=g++-8"
+        - COMPILE=main
+    - name: g++-8 test
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-8
+      env:
+        - COMPILERS="CC=gcc-8 CXX=g++-8"
+        - COMPILE=tests
     - name: clang-3.9 daemon
       addons:
         apt:

--- a/src/cryptonote_basic/account.cpp
+++ b/src/cryptonote_basic/account.cpp
@@ -182,7 +182,7 @@ void account_base::create_from_device(const std::string &device_name)
 void account_base::create_from_viewkey(const cryptonote::account_public_address &address, const crypto::secret_key &viewkey)
 {
 	crypto::secret_key fake;
-	memset(&fake, 0, sizeof(fake));
+	fake.scrub();
 	create_from_keys(address, fake, viewkey);
 }
 //-----------------------------------------------------------------

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -991,7 +991,7 @@ bool t_rpc_command_executor::print_transaction_pool_stats()
 	}
 	else
 	{
-		memset(&res.pool_stats, 0, sizeof(res.pool_stats));
+		res.pool_stats.clear();
 		if(!m_rpc_server->on_get_transaction_pool_stats(req, res, false) || res.status != CORE_RPC_STATUS_OK)
 		{
 			tools::fail_msg_writer() << make_error(fail_message, res.status);

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -1556,6 +1556,23 @@ struct txpool_stats
 	std::vector<txpool_histo> histo;
 	uint32_t num_double_spends;
 
+	void clear()
+	{	
+		bytes_total = 0;
+		bytes_min = 0;
+		bytes_max = 0;
+		bytes_med = 0;
+		fee_total = 0;
+		oldest = 0;
+		txs_total = 0;
+		num_failing = 0;
+		num_10m = 0;
+		num_not_relayed = 0;
+		histo_98pc = 0;
+		histo.clear();
+		num_double_spends = 0;
+	}
+
 	BEGIN_KV_SERIALIZE_MAP()
 	KV_SERIALIZE(bytes_total)
 	KV_SERIALIZE(bytes_min)


### PR DESCRIPTION
fix error like `src/cryptonote_basic/account.cpp:185:31: error: ‘void* memset(void*, int, size_t)’ clearing an object of non-trivial type ‘using secret_key = struct tools::scrubbed<crypto::ec_scalar>’ {aka ‘struct tools::scrubbed<crypto::ec_scalar>’}; use assignment or value-initialization instead [-Werror=class-memaccess]`

- remove usage of `memset` to reset complex types like `std::vector`
- add `clear()` method to `txpool_stats`
- travis CI add gcc 8 toolchain