### PR TITLE
Implement Windows Unicode APIs

### DIFF
--- a/src/address_validator/address_validator.cpp
+++ b/src/address_validator/address_validator.cpp
@@ -42,6 +42,7 @@
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 
+#include "common/command_line.h"
 #include "address_validator/address_validator.h"
 #include "string_tools.h"
 #include "cryptonote_basic/cryptonote_basic_impl.h"
@@ -187,6 +188,17 @@ void address_validator::print(writer &out, const std::string &addr_str, const ad
 //----------------------------------------------------------------------------------------------------
 int main(int argc, char *argv[])
 {
+#ifdef WIN32
+	std::vector<std::string> args;
+	std::vector<char*> argptrs;
+	command_line::set_console_utf8();
+	if(command_line::get_windows_args(args, argptrs))
+	{
+		argc = args.size();
+		argv = argptrs.data();
+	}
+#endif
+
 	namespace po = boost::program_options;
 
 	po::options_description desc("Validate RYO/SUMOKOIN addresses and show properties\n\n"

--- a/src/blockchain_utilities/blockchain_blackball.cpp
+++ b/src/blockchain_utilities/blockchain_blackball.cpp
@@ -167,6 +167,17 @@ static bool for_all_transactions(const std::string &filename, const std::functio
 
 int main(int argc, char *argv[])
 {
+#ifdef WIN32
+	std::vector<std::string> args;
+	std::vector<char*> argptrs;
+	command_line::set_console_utf8();
+	if(command_line::get_windows_args(args, argptrs))
+	{
+		argc = args.size();
+		argv = argptrs.data();
+	}
+#endif
+
 	TRY_ENTRY();
 
 	epee::string_tools::set_module_name_and_folder(argv[0]);

--- a/src/blockchain_utilities/blockchain_export.cpp
+++ b/src/blockchain_utilities/blockchain_export.cpp
@@ -59,6 +59,17 @@ using namespace epee;
 
 int main(int argc, char *argv[])
 {
+#ifdef WIN32
+	std::vector<std::string> args;
+	std::vector<char*> argptrs;
+	command_line::set_console_utf8();
+	if(command_line::get_windows_args(args, argptrs))
+	{
+		argc = args.size();
+		argv = argptrs.data();
+	}
+#endif
+
 	TRY_ENTRY();
 
 	epee::string_tools::set_module_name_and_folder(argv[0]);

--- a/src/blockchain_utilities/blockchain_import.cpp
+++ b/src/blockchain_utilities/blockchain_import.cpp
@@ -572,6 +572,17 @@ quitting:
 
 int main(int argc, char *argv[])
 {
+#ifdef WIN32
+	std::vector<std::string> args;
+	std::vector<char*> argptrs;
+	command_line::set_console_utf8();
+	if(command_line::get_windows_args(args, argptrs))
+	{
+		argc = args.size();
+		argv = argptrs.data();
+	}
+#endif
+
 	TRY_ENTRY();
 
 	epee::string_tools::set_module_name_and_folder(argv[0]);

--- a/src/blockchain_utilities/blockchain_usage.cpp
+++ b/src/blockchain_utilities/blockchain_usage.cpp
@@ -99,6 +99,17 @@ struct reference
 
 int main(int argc, char *argv[])
 {
+#ifdef WIN32
+	std::vector<std::string> args;
+	std::vector<char*> argptrs;
+	command_line::set_console_utf8();
+	if(command_line::get_windows_args(args, argptrs))
+	{
+		argc = args.size();
+		argv = argptrs.data();
+	}
+#endif
+
 	TRY_ENTRY();
 
 	epee::string_tools::set_module_name_and_folder(argv[0]);

--- a/src/common/command_line.h
+++ b/src/common/command_line.h
@@ -311,6 +311,11 @@ inline bool has_arg(const boost::program_options::variables_map &vm, const arg_d
 	return get_arg(vm, arg);
 }
 
+#ifdef WIN32
+bool get_windows_args(std::vector<std::string>& args, std::vector<char*>& argptrs);
+void set_console_utf8();
+#endif
+
 extern const arg_descriptor<bool> arg_help;
 extern const arg_descriptor<bool> arg_version;
 }

--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -72,11 +72,21 @@
 namespace po = boost::program_options;
 namespace bf = boost::filesystem;
 
-int main(int argc, char const *argv[])
+int main(int argc, char* argv[])
 {
+#ifdef WIN32
+	std::vector<std::string> args;
+	std::vector<char*> argptrs;
+	command_line::set_console_utf8();
+	if(command_line::get_windows_args(args, argptrs))
+	{
+		argc = args.size();
+		argv = argptrs.data();
+	}
+#endif
+
 	try
 	{
-
 		// TODO parse the debug options like set log level right here at start
 
 		tools::on_startup();

--- a/src/daemonizer/daemonizer.h
+++ b/src/daemonizer/daemonizer.h
@@ -66,7 +66,7 @@ boost::filesystem::path get_relative_path_base(
    */
 template <typename T_executor>
 bool daemonize(
-	int argc, char const *argv[], T_executor &&executor // universal ref
+	int argc, char* argv[], T_executor &&executor // universal ref
 	,
 	boost::program_options::variables_map const &vm);
 }

--- a/src/daemonizer/posix_daemonizer.inl
+++ b/src/daemonizer/posix_daemonizer.inl
@@ -84,7 +84,7 @@ inline boost::filesystem::path get_relative_path_base(
 
 template <typename T_executor>
 inline bool daemonize(
-	int argc, char const *argv[], T_executor &&executor // universal ref
+	int argc, char* argv[], T_executor &&executor // universal ref
 	,
 	boost::program_options::variables_map const &vm)
 {

--- a/src/daemonizer/windows_daemonizer.inl
+++ b/src/daemonizer/windows_daemonizer.inl
@@ -67,7 +67,7 @@ const command_line::arg_descriptor<bool> arg_stop_service = {
 const command_line::arg_descriptor<bool> arg_is_service = {
 	"run-as-service", "Hidden -- true if running as windows service"};
 
-std::string get_argument_string(int argc, char const *argv[])
+std::string get_argument_string(int argc, char* argv[])
 {
 	std::string result = "";
 	for(int i = 1; i < argc; ++i)
@@ -129,7 +129,7 @@ inline boost::filesystem::path get_relative_path_base(
 
 template <typename T_executor>
 inline bool daemonize(
-	int argc, char const *argv[], T_executor &&executor // universal ref
+	int argc, char* argv[], T_executor &&executor // universal ref
 	,
 	boost::program_options::variables_map const &vm)
 {

--- a/src/gen_multisig/gen_multisig.cpp
+++ b/src/gen_multisig/gen_multisig.cpp
@@ -182,6 +182,17 @@ static bool generate_multisig(uint32_t threshold, uint32_t total, const std::str
 
 int main(int argc, char *argv[])
 {
+#ifdef WIN32
+	std::vector<std::string> args;
+	std::vector<char*> argptrs;
+	command_line::set_console_utf8();
+	if(command_line::get_windows_args(args, argptrs))
+	{
+		argc = args.size();
+		argv = argptrs.data();
+	}
+#endif
+
 	po::options_description desc_params(wallet_args::tr("Wallet options"));
 	command_line::add_arg(desc_params, arg_filename_base);
 	command_line::add_arg(desc_params, arg_scheme);

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -7572,6 +7572,15 @@ int main(int argc, char *argv[])
 	// Activate UTF-8 support for Boost filesystem classes on Windows
 	std::locale::global(boost::locale::generator().generate(""));
 	boost::filesystem::path::imbue(std::locale());
+
+	std::vector<std::string> args;
+	std::vector<char*> argptrs;
+	command_line::set_console_utf8();
+	if(command_line::get_windows_args(args, argptrs))
+	{
+		argc = args.size();
+		argv = argptrs.data();
+	}
 #endif
 
 	po::options_description desc_params(wallet_args::tr("Wallet options"));

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -83,6 +83,7 @@
 #include <thread>
 
 #ifdef WIN32
+#include <windows.h>
 #include <boost/filesystem.hpp>
 #include <boost/locale.hpp>
 #endif
@@ -157,28 +158,6 @@ const command_line::arg_descriptor<bool> arg_use_english_language_names = {"use-
 
 const command_line::arg_descriptor<std::vector<std::string>> arg_command = {"command", ""};
 
-#ifdef WIN32
-// Translate from CP850 to UTF-8;
-// std::getline for a Windows console returns a string in CP437 or CP850; as simplewallet,
-// like all of Ryo, is assumed to work internally with UTF-8 throughout, even on Windows
-// (although only implemented partially), a translation to UTF-8 is needed for input.
-//
-// Note that if a program is started inside the MSYS2 shell somebody already translates
-// console input to UTF-8, but it's not clear how one could detect that in order to avoid
-// double-translation; this code here thus breaks UTF-8 input within a MSYS2 shell,
-// unfortunately.
-//
-// Note also that input for passwords is NOT translated, to remain compatible with any
-// passwords containing special characters that predate this switch to UTF-8 support.
-static std::string cp850_to_utf8(const std::string &cp850_str)
-{
-	boost::locale::generator gen;
-	gen.locale_cache_enabled(true);
-	std::locale loc = gen("en_US.CP850");
-	return boost::locale::conv::to_utf<char>(cp850_str, loc);
-}
-#endif
-
 std::string input_line(const std::string &prompt)
 {
 #ifdef HAVE_READLINE
@@ -186,10 +165,30 @@ std::string input_line(const std::string &prompt)
 #endif
 	std::cout << prompt;
 
+#ifdef WIN32
+	HANDLE hConIn = CreateFileW(L"CONIN$", GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, OPEN_EXISTING, 0, nullptr);
+	DWORD oldMode;
+
+	FlushConsoleInputBuffer(hConIn);
+	GetConsoleMode(hConIn, &oldMode);
+	SetConsoleMode(hConIn, ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT | ENABLE_PROCESSED_INPUT);
+
+	wchar_t buffer[1024];
+	DWORD read;
+
+	ReadConsoleW(hConIn, buffer, sizeof(buffer)/sizeof(wchar_t)-1, &read, nullptr);
+	buffer[read] = 0;
+
+	SetConsoleMode(hConIn, oldMode);
+	CloseHandle(hConIn);
+ 
+	int size_needed = WideCharToMultiByte(CP_UTF8, 0, buffer, -1, NULL, 0, NULL, NULL);
+	std::string buf(size_needed, '\0');
+	WideCharToMultiByte(CP_UTF8, 0, buffer, -1, &buf[0], size_needed, NULL, NULL);
+	buf.pop_back(); //size_needed includes null that we needed to have space for
+#else
 	std::string buf;
 	std::getline(std::cin, buf);
-#ifdef WIN32
-	buf = cp850_to_utf8(buf);
 #endif
 
 	return epee::string_tools::trim(buf);

--- a/src/wallet/wallet_args.cpp
+++ b/src/wallet/wallet_args.cpp
@@ -54,8 +54,6 @@
 
 #if defined(WIN32)
 #include <crtdbg.h>
-#include <windows.h>
-#include <shellapi.h>
 #endif
 
 //#undef RYO_DEFAULT_LOG_CATEGORY
@@ -106,28 +104,6 @@ const char *tr(const char *str)
 	return i18n_translate(str, "wallet_args");
 }
 
-#ifdef WIN32
-bool get_windows_args(std::vector<std::string>& args, std::vector<char*>& argptrs)
-{
-	int nArgs = 0;
-	LPWSTR* szArgs = CommandLineToArgvW(GetCommandLineW(), &nArgs);
-
-	if(szArgs == nullptr)
-		return false;
-
-	for(int i=0; i < nArgs; i++)
-	{
-		int size_needed = WideCharToMultiByte(CP_UTF8, 0, szArgs[i], -1, NULL, 0, NULL, NULL);
-		args.emplace_back(size_needed, '\0');
-		std::string& str = args.back();
-		char* strptr = &str[0];
-		WideCharToMultiByte(CP_UTF8, 0, szArgs[i], -1, strptr, size_needed, NULL, NULL);
-		str.pop_back();
-		argptrs.emplace_back(strptr);
-	}
-}
-#endif
-
 boost::optional<boost::program_options::variables_map> main(
 	int argc, char **argv,
 	const char *const usage,
@@ -144,14 +120,6 @@ boost::optional<boost::program_options::variables_map> main(
 	namespace po = boost::program_options;
 #ifdef WIN32
 	_CrtSetDbgFlag(_CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF);
-	
-	std::vector<std::string> args;
-	std::vector<char*> argptrs;
-	if(get_windows_args(args, argptrs))
-	{
-		argc = args.size();
-		argv = argptrs.data();
-	}
 #endif
 
 	error_code = 1;

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -2998,6 +2998,17 @@ bool wallet_rpc_server::on_submit_multisig(const wallet_rpc::COMMAND_RPC_SUBMIT_
 
 int main(int argc, char **argv)
 {
+#ifdef WIN32
+	std::vector<std::string> args;
+	std::vector<char*> argptrs;
+	command_line::set_console_utf8();
+	if(command_line::get_windows_args(args, argptrs))
+	{
+		argc = args.size();
+		argv = argptrs.data();
+	}
+#endif
+
 	namespace po = boost::program_options;
 
 	const auto arg_wallet_file = wallet_args::arg_wallet_file();


### PR DESCRIPTION
Background (or let's go back to 1993):

Windows internally uses USC2 encoding. This is a grandfather of UTF-16, back from the days where 16 bits was enough for everyone.

Every single windows API function has two variants. W and A - the latter calling the W function and **converting the result to local codepage**. This is important as this isn't a lossless conversion. If the USC2 glyphs are not in user's codepage, they cannot be recreated (as Monero guys attempted to do here https://github.com/ryo-currency/ryo-currency/pull/102/commits/5762596a4876e23a4e09d218b509692346d976ed#diff-cb82e0aa6db499004305bf35f0eaafbcL161)

So the key to unicode support on Windows is to make sure either we or the underlying library calls the W variant function and then converts to UTF8. Since Windows is best at handling Windows mess, we will use Microsoft's own conversion via `WideCharToMultiByte`.

This is a generic and recurring problem. Any string going in or out of the Windows API needs to be treated this way - command line args, console input, filenames etc.