### PR TITLE
simplewallet: fix unspend output

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -6267,7 +6267,7 @@ bool simple_wallet::unspent_outputs(const std::vector<std::string> &args_)
 	auto local_args = args_;
 
 	std::set<uint32_t> subaddr_indices;
-	if(local_args.size() > 0 && local_args[0].substr(0, 6) != "index=")
+	if(local_args.size() > 0 && local_args[0].substr(0, 6) == "index=")
 	{
 		if(!parse_subaddress_indices(local_args[0], subaddr_indices))
 			return true;


### PR DESCRIPTION
Given indicies will not be parsed due to a logic mistake.

fix imported from monero: https://github.com/monero-project/monero/commit/3a4c3ac89104323cb72df4e2102c4563c92be2df