### PR TITLE
fix windows cmd line

### DIFF
--- a/src/address_validator/address_validator.cpp
+++ b/src/address_validator/address_validator.cpp
@@ -189,12 +189,11 @@ void address_validator::print(writer &out, const std::string &addr_str, const ad
 int main(int argc, char *argv[])
 {
 #ifdef WIN32
-	std::vector<std::string> args;
 	std::vector<char*> argptrs;
 	command_line::set_console_utf8();
-	if(command_line::get_windows_args(args, argptrs))
+	if(command_line::get_windows_args(argptrs))
 	{
-		argc = args.size();
+		argc = argptrs.size();
 		argv = argptrs.data();
 	}
 #endif

--- a/src/blockchain_utilities/blockchain_blackball.cpp
+++ b/src/blockchain_utilities/blockchain_blackball.cpp
@@ -168,12 +168,11 @@ static bool for_all_transactions(const std::string &filename, const std::functio
 int main(int argc, char *argv[])
 {
 #ifdef WIN32
-	std::vector<std::string> args;
 	std::vector<char*> argptrs;
 	command_line::set_console_utf8();
-	if(command_line::get_windows_args(args, argptrs))
+	if(command_line::get_windows_args(argptrs))
 	{
-		argc = args.size();
+		argc = argptrs.size();
 		argv = argptrs.data();
 	}
 #endif

--- a/src/blockchain_utilities/blockchain_export.cpp
+++ b/src/blockchain_utilities/blockchain_export.cpp
@@ -60,12 +60,11 @@ using namespace epee;
 int main(int argc, char *argv[])
 {
 #ifdef WIN32
-	std::vector<std::string> args;
 	std::vector<char*> argptrs;
 	command_line::set_console_utf8();
-	if(command_line::get_windows_args(args, argptrs))
+	if(command_line::get_windows_args(argptrs))
 	{
-		argc = args.size();
+		argc = argptrs.size();
 		argv = argptrs.data();
 	}
 #endif

--- a/src/blockchain_utilities/blockchain_import.cpp
+++ b/src/blockchain_utilities/blockchain_import.cpp
@@ -573,12 +573,11 @@ quitting:
 int main(int argc, char *argv[])
 {
 #ifdef WIN32
-	std::vector<std::string> args;
 	std::vector<char*> argptrs;
 	command_line::set_console_utf8();
-	if(command_line::get_windows_args(args, argptrs))
+	if(command_line::get_windows_args(argptrs))
 	{
-		argc = args.size();
+		argc = argptrs.size();
 		argv = argptrs.data();
 	}
 #endif

--- a/src/blockchain_utilities/blockchain_usage.cpp
+++ b/src/blockchain_utilities/blockchain_usage.cpp
@@ -100,12 +100,11 @@ struct reference
 int main(int argc, char *argv[])
 {
 #ifdef WIN32
-	std::vector<std::string> args;
 	std::vector<char*> argptrs;
 	command_line::set_console_utf8();
-	if(command_line::get_windows_args(args, argptrs))
+	if(command_line::get_windows_args(argptrs))
 	{
-		argc = args.size();
+		argc = argptrs.size();
 		argv = argptrs.data();
 	}
 #endif

--- a/src/common/command_line.h
+++ b/src/common/command_line.h
@@ -312,7 +312,7 @@ inline bool has_arg(const boost::program_options::variables_map &vm, const arg_d
 }
 
 #ifdef WIN32
-bool get_windows_args(std::vector<std::string>& args, std::vector<char*>& argptrs);
+bool get_windows_args(std::vector<char*>& argptrs);
 void set_console_utf8();
 #endif
 

--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -75,12 +75,11 @@ namespace bf = boost::filesystem;
 int main(int argc, char* argv[])
 {
 #ifdef WIN32
-	std::vector<std::string> args;
 	std::vector<char*> argptrs;
 	command_line::set_console_utf8();
-	if(command_line::get_windows_args(args, argptrs))
+	if(command_line::get_windows_args(argptrs))
 	{
-		argc = args.size();
+		argc = argptrs.size();
 		argv = argptrs.data();
 	}
 #endif

--- a/src/gen_multisig/gen_multisig.cpp
+++ b/src/gen_multisig/gen_multisig.cpp
@@ -183,12 +183,11 @@ static bool generate_multisig(uint32_t threshold, uint32_t total, const std::str
 int main(int argc, char *argv[])
 {
 #ifdef WIN32
-	std::vector<std::string> args;
 	std::vector<char*> argptrs;
 	command_line::set_console_utf8();
-	if(command_line::get_windows_args(args, argptrs))
+	if(command_line::get_windows_args(argptrs))
 	{
-		argc = args.size();
+		argc = argptrs.size();
 		argv = argptrs.data();
 	}
 #endif

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -7573,12 +7573,11 @@ int main(int argc, char *argv[])
 	std::locale::global(boost::locale::generator().generate(""));
 	boost::filesystem::path::imbue(std::locale());
 
-	std::vector<std::string> args;
 	std::vector<char*> argptrs;
 	command_line::set_console_utf8();
-	if(command_line::get_windows_args(args, argptrs))
+	if(command_line::get_windows_args(argptrs))
 	{
-		argc = args.size();
+		argc = argptrs.size();
 		argv = argptrs.data();
 	}
 #endif

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -3015,12 +3015,11 @@ bool wallet_rpc_server::on_submit_multisig(const wallet_rpc::COMMAND_RPC_SUBMIT_
 int main(int argc, char **argv)
 {
 #ifdef WIN32
-	std::vector<std::string> args;
 	std::vector<char*> argptrs;
 	command_line::set_console_utf8();
-	if(command_line::get_windows_args(args, argptrs))
+	if(command_line::get_windows_args(argptrs))
 	{
-		argc = args.size();
+		argc = argptrs.size();
 		argv = argptrs.data();
 	}
 #endif


### PR DESCRIPTION
Using `std::string` in this context produced a bug where small string optimisations kicked in. Since this is C-style API, I opted for C-style method of a single combined-string buffer instead.

The buffer is not deleted at all. The only safe place where we can do it is just before the program close. And once my professor compared that kind of thing to cleaning up your bedroom just before a wrecking ball drives through your house.