### PR TITLE
fix invalid memory access

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -8627,7 +8627,7 @@ uint64_t wallet2::import_key_images(const std::vector<std::pair<crypto::key_imag
 	std::unordered_set<crypto::hash> spent_txids; // For each spent key image, search for a tx in m_transfers that uses it as input.
 	std::vector<size_t> swept_transfers;		  // If such a spending tx wasn't found in m_transfers, this means the spending tx
 												  // was created by sweep_all, so we can't know the spent height and other detailed info.
-	for(size_t i = 0; i < m_transfers.size(); ++i)
+	for(size_t i = 0; i < signed_key_images.size(); ++i)
 	{
 		transfer_details &td = m_transfers[i];
 		uint64_t amount = td.amount();


### PR DESCRIPTION
During the scan of key images for sweeped transfers memory outside of the range of requested key images is accessed.
https://github.com/ryo-currency/ryo-currency/blob/59a7b4ce2c1d1f02567fbcd009e337d19a87d345/src/wallet/wallet2.cpp#L8634
This fix also avoid that transfers without a key image will be scanned during the import of keys.

- change the loop to scan only as much transaction as we have signed key images

import of monero pull request: https://github.com/monero-project/monero/pull/4041