### PR TITLE
fix gtest MinGW compile

### DIFF
--- a/tests/gtest/cmake/internal_utils.cmake
+++ b/tests/gtest/cmake/internal_utils.cmake
@@ -46,7 +46,7 @@ endmacro()
 # Google Mock.  You can tweak these definitions to suit your need.  A
 # variable's value is empty before it's explicitly assigned to.
 macro(config_compiler_and_linker)
-  if (NOT gtest_disable_pthreads)
+  if (NOT gtest_disable_pthreads AND NOT MINGW)
     # Defines CMAKE_USE_PTHREADS_INIT and CMAKE_THREAD_LIBS_INIT.
     find_package(Threads)
   endif()

--- a/tests/gtest/include/gtest/internal/gtest-port.h
+++ b/tests/gtest/include/gtest/internal/gtest-port.h
@@ -1594,10 +1594,7 @@ class GTEST_API_ Notification
 };
 #endif // GTEST_HAS_NOTIFICATION_
 
-// On MinGW, we can have both GTEST_OS_WINDOWS and GTEST_HAS_PTHREAD
-// defined, but we don't want to use MinGW's pthreads implementation, which
-// has conformance problems with some versions of the POSIX standard.
-#if GTEST_HAS_PTHREAD && !GTEST_OS_WINDOWS_MINGW
+# if GTEST_HAS_PTHREAD
 
 // As a C-function, ThreadFuncWithCLinkage cannot be templated itself.
 // Consequently, it cannot select a correct instantiation of ThreadWithParam


### PR DESCRIPTION
Gtest is not using pthreads under MinGW and therefore end in compile issues.
The fix for this issue can be found https://github.com/google/googletest/pull/621

This is a backport of the fix into the current used gtest version.