### PR TITLE
wallet2: throw exception on refresh error

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -9206,6 +9206,9 @@ size_t wallet2::import_multisig(std::vector<cryptonote::blobdata> blobs)
 	}
 	catch(...)
 	{
+		m_multisig_rescan_info = NULL;
+		m_multisig_rescan_k = NULL;
+		throw;
 	}
 	m_multisig_rescan_info = NULL;
 	m_multisig_rescan_k = NULL;


### PR DESCRIPTION
In a case where the refresh fails, throw an error.

Import of the Monero PR: https://github.com/monero-project/monero/pull/4360