### PR TITLE
dns_util: add new DNSSEC trust anchor for rollover

### DIFF
--- a/src/common/dns_utils.cpp
+++ b/src/common/dns_utils.cpp
@@ -113,10 +113,16 @@ get_builtin_cert(void)
 */
 
 /** return the built in root DS trust anchor */
-static const char *
+static const char* const*
 get_builtin_ds(void)
 {
-	return ". IN DS 19036 8 2 49AAC11D7B6F6446702E54A1607371607A1A41855200FD2CE1CDDE32F24E8FB5\n";
+	static const char * const ds[] =
+	{
+		". IN DS 19036 8 2 49AAC11D7B6F6446702E54A1607371607A1A41855200FD2CE1CDDE32F24E8FB5\n",
+		". IN DS 20326 8 2 E06D44B80B8F1D39A95C0B0D7C65D08458E880409BBC683457104237C7F8EC8D\n",
+		nullptr // mark the last entry
+	};
+	return ds;
 }
 
 /************************************************************
@@ -255,7 +261,12 @@ DNSResolver::DNSResolver() : m_data(new DNSResolverData())
 		ub_ctx_hosts(m_data->m_ub_context, NULL);
 	}
 
-	ub_ctx_add_ta(m_data->m_ub_context, string_copy(::get_builtin_ds()));
+	const char * const *ds = ::get_builtin_ds();
+	while (*ds)
+	{
+		MINFO("adding trust anchor: " << *ds);
+		ub_ctx_add_ta(m_data->m_ub_context, string_copy(*ds++));
+	}
 }
 
 DNSResolver::~DNSResolver()


### PR DESCRIPTION
DNS anchors is updated on 11th of october 2018.

https://www.icann.org/resources/pages/ksk-rollover

import of Monero pr: https://github.com/monero-project/monero/pull/4309