### PR TITLE
Fixed RYO_RELEASE_NAME variable

### DIFF
--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -145,7 +145,7 @@ int main(int argc, char* argv[])
 
 		if(command_line::get_arg(vm, command_line::arg_help))
 		{
-			std::cout << "Ryo '" << RYO_RELEASE_NAME << "' (" << RYO_VERSION_FULL << ")" << ENDL << ENDL;
+			std::cout << "Scamcoin '" << RYO_RELEASE_NAME << "' (" << RYO_VERSION_FULL << ")" << ENDL << ENDL;
 			std::cout << "Usage: " + std::string{argv[0]} + " [options|settings] [daemon_command...]" << std::endl
 					  << std::endl;
 			std::cout << visible_options << std::endl;
@@ -155,7 +155,7 @@ int main(int argc, char* argv[])
 		// Monero Version
 		if(command_line::get_arg(vm, command_line::arg_version))
 		{
-			std::cout << "Ryo '" << RYO_RELEASE_NAME << "' (" << RYO_VERSION_FULL << ")" << ENDL;
+			std::cout << "Scamcoin '" << RYO_RELEASE_NAME << "' (" << RYO_VERSION_FULL << ")" << ENDL;
 			return 0;
 		}
 


### PR DESCRIPTION
Everyone knows this had to be fixed long ago.