### PR TITLE
PoW fix

### DIFF
--- a/src/crypto/pow_hash/cn_slow_hash.hpp
+++ b/src/crypto/pow_hash/cn_slow_hash.hpp
@@ -62,7 +62,7 @@
 // Cryptonight-heavy
 #define cn_v2_hash_t cn_slow_hash<4 * 1024 * 1024, 0x40000, 1>
 // Cryptonight-GPU
-#define cn_v3_hash_t cn_slow_hash<2 * 1024 * 1024, 0x10000, 2>
+#define cn_v3_hash_t cn_slow_hash<2 * 1024 * 1024, 0xC000, 2>
 
 // Use the types below
 template <size_t MEMORY, size_t ITER, size_t VERSION>

--- a/src/crypto/pow_hash/cn_slow_hash_hard_arm.cpp
+++ b/src/crypto/pow_hash/cn_slow_hash_hard_arm.cpp
@@ -415,13 +415,15 @@ inline void sub_round(const float32x4_t& n0, const float32x4_t& n1, const float3
 	float32x4_t ln1 = vaddq_f32(n1, c);
 	float32x4_t nn = vmulq_f32(n0, c);
 	nn = vmulq_f32(ln1, vmulq_f32(nn, nn));
-	veorq_f32(nn, 0x00000001);
+	vandq_f32(nn, 0xFEFFFFFF);
+	vorq_f32(nn, 0x00800000);
 	n = vaddq_f32(n, nn);
 
 	float32x4_t ln3 = vsubq_f32(n3, c);
 	float32x4_t dd = vmulq_f32(n2, c);
 	dd = vmulq_f32(ln3, vmulq_f32(dd, dd));
-	veorq_f32(dd, 0x00000001);
+	vandq_f32(dd, 0xFEFFFFFF);
+	vorq_f32(dd, 0x00800000);
 	d = vaddq_f32(d, dd);
 
 	//Constant feedback
@@ -448,6 +450,7 @@ inline void round_compute(const float32x4_t& n0, const float32x4_t& n1, const fl
 	sub_round(n0, n3, n2, n1, rnd_c, n, d, c);
 
 	// Make sure abs(d) > 2.0 - this prevents division by zero and accidental overflows by division by < 1.0
+	vandq_f32(d, 0xFF7FFFFF);
 	vorq_f32(d, 0x40000000);
 	r = vaddq_f32(r, vdivq_f32(n, d));
 }

--- a/src/crypto/pow_hash/cn_slow_hash_soft.cpp
+++ b/src/crypto/pow_hash/cn_slow_hash_soft.cpp
@@ -439,11 +439,7 @@ void cn_slow_hash<MEMORY, ITER, VERSION>::explode_scratchpad_soft()
 inline void generate_512(uint64_t idx, const uint64_t* in, uint8_t* out)
 {
 	constexpr size_t hash_size = 200; // 25x8 bytes
-#if defined(__arm__) || defined(__aarch64__)
 	alignas(16) uint64_t hash[25];
-#else
-	alignas(128) uint64_t hash[25];
-#endif
 
 	memcpy(hash, in, hash_size);
 	hash[0] ^= idx;


### PR DESCRIPTION
- Fix a bug in the proof of work

Flipping a singe bit in +0 (0x00000000) or -0 (0x80000000) will produce a denormal number. This made us stray into off-specification behaviour on AMD

- Iteration reduction

Reduce iterations to 49152 (3MB written) to aid CPU verification. Ballpark hash time for a decent CPU is around 100ms / hash.