### PR TITLE
fix mem leakage

### DIFF
--- a/contrib/epee/demo/iface/transport_defs.h
+++ b/contrib/epee/demo/iface/transport_defs.h
@@ -10,7 +10,7 @@ struct some_test_subdata
 {
 	std::string m_str;
 
-	BEGIN_KV_SERIALIZE_MAP()
+	BEGIN_KV_SERIALIZE_MAP(some_test_subdata)
 	KV_SERIALIZE(m_str)
 	END_KV_SERIALIZE_MAP()
 };
@@ -44,7 +44,7 @@ struct some_test_data
 	epee::serialization::storage_entry m_storage_entry_int;
 	epee::serialization::storage_entry m_storage_entry_string;
 
-	BEGIN_KV_SERIALIZE_MAP()
+	BEGIN_KV_SERIALIZE_MAP(some_test_data)
 	KV_SERIALIZE(m_str)
 	KV_SERIALIZE(m_uint64)
 	KV_SERIALIZE(m_uint32)
@@ -86,7 +86,7 @@ struct COMMAND_EXAMPLE_1
 		std::string example_string_data;
 		some_test_data sub;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(example_string_data)
 		KV_SERIALIZE(sub)
 		END_KV_SERIALIZE_MAP()
@@ -97,7 +97,7 @@ struct COMMAND_EXAMPLE_1
 		bool m_success;
 		std::list<some_test_data> subs;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(m_success)
 		KV_SERIALIZE(subs)
 		END_KV_SERIALIZE_MAP()
@@ -112,7 +112,7 @@ struct COMMAND_EXAMPLE_2
 	{
 		std::string example_string_data2;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(example_string_data2)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -121,7 +121,7 @@ struct COMMAND_EXAMPLE_2
 	{
 		bool m_success;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(m_success)
 		END_KV_SERIALIZE_MAP()
 	};

--- a/contrib/epee/include/net/jsonrpc_structs.h
+++ b/contrib/epee/include/net/jsonrpc_structs.h
@@ -18,7 +18,7 @@ struct request
 	epee::serialization::storage_entry id;
 	t_param params;
 
-	BEGIN_KV_SERIALIZE_MAP()
+	BEGIN_KV_SERIALIZE_MAP(request)
 	KV_SERIALIZE(jsonrpc)
 	KV_SERIALIZE(id)
 	KV_SERIALIZE(method)
@@ -30,7 +30,7 @@ struct error
 {
 	int64_t code;
 	std::string message;
-	BEGIN_KV_SERIALIZE_MAP()
+	BEGIN_KV_SERIALIZE_MAP(error)
 	KV_SERIALIZE(code)
 	KV_SERIALIZE(message)
 	END_KV_SERIALIZE_MAP()
@@ -38,13 +38,13 @@ struct error
 
 struct dummy_error
 {
-	BEGIN_KV_SERIALIZE_MAP()
+	BEGIN_KV_SERIALIZE_MAP(dummy_error)
 	END_KV_SERIALIZE_MAP()
 };
 
 struct dummy_result
 {
-	BEGIN_KV_SERIALIZE_MAP()
+	BEGIN_KV_SERIALIZE_MAP(dummy_result)
 	END_KV_SERIALIZE_MAP()
 };
 
@@ -55,7 +55,7 @@ struct response
 	t_param result;
 	epee::serialization::storage_entry id;
 	t_error error;
-	BEGIN_KV_SERIALIZE_MAP()
+	BEGIN_KV_SERIALIZE_MAP(response)
 	KV_SERIALIZE(jsonrpc)
 	KV_SERIALIZE(id)
 	KV_SERIALIZE(result)
@@ -69,7 +69,7 @@ struct response<t_param, dummy_error>
 	std::string jsonrpc;
 	t_param result;
 	epee::serialization::storage_entry id;
-	BEGIN_KV_SERIALIZE_MAP()
+	BEGIN_KV_SERIALIZE_MAP(response)
 	KV_SERIALIZE(jsonrpc)
 	KV_SERIALIZE(id)
 	KV_SERIALIZE(result)
@@ -82,7 +82,7 @@ struct response<dummy_result, t_error>
 	std::string jsonrpc;
 	t_error error;
 	epee::serialization::storage_entry id;
-	BEGIN_KV_SERIALIZE_MAP()
+	BEGIN_KV_SERIALIZE_MAP(response)
 	KV_SERIALIZE(jsonrpc)
 	KV_SERIALIZE(id)
 	KV_SERIALIZE(error)

--- a/contrib/epee/include/net/net_utils_base.h
+++ b/contrib/epee/include/net/net_utils_base.h
@@ -73,7 +73,7 @@ class ipv4_network_address
 	static constexpr uint8_t get_type_id() noexcept { return ID; }
 
 	static const uint8_t ID = 1;
-	BEGIN_KV_SERIALIZE_MAP()
+	BEGIN_KV_SERIALIZE_MAP(ipv4_network_address)
 	KV_SERIALIZE(m_ip)
 	KV_SERIALIZE(m_port)
 	END_KV_SERIALIZE_MAP()
@@ -157,7 +157,7 @@ class network_address
 		virtual uint8_t get_type_id() const override { return value.get_type_id(); }
 	};
 
-	std::shared_ptr<interface> self;
+	std::shared_ptr<interface> self = nullptr;
 
 	template <typename Type>
 	Type &as_mutable() const
@@ -171,7 +171,6 @@ class network_address
 	}
 
   public:
-	network_address() : self(nullptr) {}
 	template <typename T>
 	network_address(const T &src)
 		: self(std::make_shared<implementation<T>>(src)) {}
@@ -186,7 +185,7 @@ class network_address
 	template <typename Type>
 	const Type &as() const { return as_mutable<const Type>(); }
 
-	BEGIN_KV_SERIALIZE_MAP()
+	BEGIN_KV_SERIALIZE_MAP(network_address)
 	uint8_t type = is_store ? this_ref.get_type_id() : 0;
 	if(!epee::serialization::selector<is_store>::serialize(type, stg, hparent_section, "type"))
 		return false;

--- a/contrib/epee/include/serialization/keyvalue_serialization.h
+++ b/contrib/epee/include/serialization/keyvalue_serialization.h
@@ -42,8 +42,16 @@ namespace epee
 /************************************************************************/
 /* Serialize map declarations                                           */
 /************************************************************************/
-#define BEGIN_KV_SERIALIZE_MAP()                                                                                 \
+#define BEGIN_KV_SERIALIZE_MAP(class_name)                                                                       \
   public:                                                                                                        \
+	class_name(bool non_first = true)                                                                            \
+	{                                                                                                            \
+		if(non_first)                                                                                            \
+		{                                                                                                        \
+			static typename std::remove_pointer<decltype(this)>::type y(false);                                           \
+			*this = y;                                                                                           \
+		}                                                                                                        \
+	}                                                                                                            \
 	template <class t_storage>                                                                                   \
 	bool store(t_storage &st, typename t_storage::hsection hparent_section = nullptr) const                      \
 	{                                                                                                            \
@@ -64,7 +72,7 @@ namespace epee
 		catch(const std::exception &err)                                                                         \
 		{                                                                                                        \
 			(void)(err);                                                                                         \
-			GULPS_ERRORF("Exception on unserializing: {}", err.what());                                             \
+			GULPS_ERRORF("Exception on unserializing: {}", err.what());                                          \
 			return false;                                                                                        \
 		}                                                                                                        \
 	}                                                                                                            \

--- a/contrib/epee/include/serialization/keyvalue_serialization.h
+++ b/contrib/epee/include/serialization/keyvalue_serialization.h
@@ -35,7 +35,7 @@
 #include <boost/foreach.hpp>
 #include <boost/utility/value_init.hpp>
 
-#include "common/gulps.hpp"	
+#include "common/gulps.hpp"
 
 namespace epee
 {
@@ -43,14 +43,14 @@ namespace epee
 /* Serialize map declarations                                           */
 /************************************************************************/
 #define BEGIN_KV_SERIALIZE_MAP(class_name)                                                                       \
+  private:                                                                                                       \
+	class epee_zero{};                                                                                           \
+	class_name(const epee_zero){}                                                                                \
   public:                                                                                                        \
-	class_name(bool non_first = true)                                                                            \
+	class_name()                                                                                                 \
 	{                                                                                                            \
-		if(non_first)                                                                                            \
-		{                                                                                                        \
-			static typename std::remove_pointer<decltype(this)>::type y(false);                                           \
-			*this = y;                                                                                           \
-		}                                                                                                        \
+		static typename std::remove_pointer<decltype(this)>::type set_zero(epee_zero{});                         \
+		*this = set_zero;                                                                                        \
 	}                                                                                                            \
 	template <class t_storage>                                                                                   \
 	bool store(t_storage &st, typename t_storage::hsection hparent_section = nullptr) const                      \

--- a/contrib/epee/tests/src/storages/portable_storages_test.h
+++ b/contrib/epee/tests/src/storages/portable_storages_test.h
@@ -42,7 +42,7 @@ struct port_test_struct_sub
 {
 	std::string m_str;
 
-	BEGIN_KV_SERIALIZE_MAP()
+	BEGIN_KV_SERIALIZE_MAP(port_test_struct_sub)
 	KV_SERIALIZE_VAL(m_str)
 	END_KV_SERIALIZE_MAP()
 };
@@ -83,7 +83,7 @@ struct port_test_struct
 	port_test_struct_sub m_subobj;
 	std::list<port_test_struct> m_list_of_self;
 
-	BEGIN_KV_SERIALIZE_MAP()
+	BEGIN_KV_SERIALIZE_MAP(port_test_struct)
 	KV_SERIALIZE_VAL(m_str)
 	KV_SERIALIZE_VAL(m_uint64)
 	KV_SERIALIZE_VAL(m_uint32)

--- a/src/checkpoints/checkpoints.cpp
+++ b/src/checkpoints/checkpoints.cpp
@@ -68,7 +68,7 @@ struct t_hashline
 {
 	uint64_t height;  //!< the height of the checkpoint
 	std::string hash; //!< the hash for the checkpoint
-	BEGIN_KV_SERIALIZE_MAP()
+	BEGIN_KV_SERIALIZE_MAP(t_hashline)
 	KV_SERIALIZE(height)
 	KV_SERIALIZE(hash)
 	END_KV_SERIALIZE_MAP()
@@ -80,7 +80,7 @@ struct t_hashline
 struct t_hash_json
 {
 	std::vector<t_hashline> hashlines; //!< the checkpoint lines from the file
-	BEGIN_KV_SERIALIZE_MAP()
+	BEGIN_KV_SERIALIZE_MAP(t_hash_json)
 	KV_SERIALIZE(hashlines)
 	END_KV_SERIALIZE_MAP()
 };

--- a/src/cryptonote_basic/account.cpp
+++ b/src/cryptonote_basic/account.cpp
@@ -86,16 +86,6 @@ void account_keys::set_device(hw::device &hwdev)
 }
 
 //-----------------------------------------------------------------
-account_base::account_base()
-{
-	set_null();
-}
-//-----------------------------------------------------------------
-void account_base::set_null()
-{
-	m_keys = account_keys();
-}
-//-----------------------------------------------------------------
 void account_base::forget_spend_key()
 {
 	m_keys.m_spend_secret_key = crypto::secret_key();

--- a/src/cryptonote_basic/account.h
+++ b/src/cryptonote_basic/account.h
@@ -65,7 +65,7 @@ struct account_keys
 	crypto::secret_key_16 m_short_seed;
 	hw::device *m_device = &hw::get_device("default");
 
-	BEGIN_KV_SERIALIZE_MAP()
+	BEGIN_KV_SERIALIZE_MAP(account_keys)
 	KV_SERIALIZE(m_account_address)
 	KV_SERIALIZE_VAL_POD_AS_BLOB_FORCE(m_spend_secret_key)
 	KV_SERIALIZE_VAL_POD_AS_BLOB_FORCE(m_view_secret_key)
@@ -85,7 +85,6 @@ struct account_keys
 class account_base
 {
   public:
-	account_base();
 
 	inline crypto::secret_key_16 generate_new(uint8_t acc_opt)
 	{
@@ -141,7 +140,7 @@ class account_base
 
 	static constexpr uint64_t EARLIEST_TIMESTAMP = 1483228800; // 01-01-2017 00:00
 
-	BEGIN_KV_SERIALIZE_MAP()
+	BEGIN_KV_SERIALIZE_MAP(account_base)
 	KV_SERIALIZE(m_keys)
 	KV_SERIALIZE(m_creation_timestamp)
 	KV_SERIALIZE(m_acc_opt)
@@ -149,9 +148,8 @@ class account_base
 
   private:
 	crypto::secret_key_16 generate();
-	void set_null();
 
-	account_keys m_keys;
+	account_keys m_keys = account_keys();
 	uint64_t m_creation_timestamp;
 	uint8_t m_acc_opt;
 };

--- a/src/cryptonote_basic/cryptonote_basic.h
+++ b/src/cryptonote_basic/cryptonote_basic.h
@@ -454,6 +454,9 @@ struct block : public block_header
 /************************************************************************/
 struct account_public_address
 {
+	account_public_address(const crypto::public_key m_spend_public_key, const  crypto::public_key m_view_public_key) : m_spend_public_key(m_spend_public_key), 
+			      m_view_public_key(m_view_public_key) {}
+  
 	crypto::public_key m_spend_public_key;
 	crypto::public_key m_view_public_key;
 
@@ -462,7 +465,7 @@ struct account_public_address
 	FIELD(m_view_public_key)
 	END_SERIALIZE()
 
-	BEGIN_KV_SERIALIZE_MAP()
+	BEGIN_KV_SERIALIZE_MAP(account_public_address)
 	KV_SERIALIZE_VAL_POD_AS_BLOB_FORCE(m_spend_public_key)
 	KV_SERIALIZE_VAL_POD_AS_BLOB_FORCE(m_view_public_key)
 	END_KV_SERIALIZE_MAP()

--- a/src/cryptonote_basic/cryptonote_basic_impl.cpp
+++ b/src/cryptonote_basic/cryptonote_basic_impl.cpp
@@ -73,6 +73,8 @@ namespace cryptonote
 
 struct integrated_address
 {
+	integrated_address(account_public_address adr, crypto::hash8 payment_id) : adr(adr), payment_id(payment_id) {}
+    
 	account_public_address adr;
 	crypto::hash8 payment_id;
 
@@ -81,7 +83,7 @@ struct integrated_address
 	FIELD(payment_id)
 	END_SERIALIZE()
 
-	BEGIN_KV_SERIALIZE_MAP()
+	BEGIN_KV_SERIALIZE_MAP(integrated_address)
 	KV_SERIALIZE(adr)
 	KV_SERIALIZE(payment_id)
 	END_KV_SERIALIZE_MAP()
@@ -89,13 +91,15 @@ struct integrated_address
 
 struct kurz_address
 {
+	kurz_address(crypto::public_key m_public_key) : m_public_key(m_public_key) {}
+	
 	crypto::public_key m_public_key;
 
 	BEGIN_SERIALIZE_OBJECT()
 	FIELD(m_public_key)
 	END_SERIALIZE()
 
-	BEGIN_KV_SERIALIZE_MAP()
+	BEGIN_KV_SERIALIZE_MAP(kurz_address)
 	KV_SERIALIZE_VAL_POD_AS_BLOB_FORCE(m_public_key)
 	END_KV_SERIALIZE_MAP()
 };
@@ -227,7 +231,7 @@ std::string get_public_address_as_str(bool subaddress, account_public_address co
 		else
 			address_prefix = config<NETTYPE>::RYO_KURZ_ADDRESS_BASE58_PREFIX;
 
-		kurz_address kadr = {adr.m_spend_public_key};
+		kurz_address kadr(adr.m_spend_public_key);
 		return tools::base58::encode_addr(address_prefix, t_serializable_object_to_blob(kadr));
 	}
 	else
@@ -251,7 +255,7 @@ std::string get_account_integrated_address_as_str(account_public_address const &
 {
 	uint64_t integrated_address_prefix = config<NETTYPE>::RYO_LONG_INTEGRATED_ADDRESS_BASE58_PREFIX;
 
-	integrated_address iadr = {adr, payment_id};
+	integrated_address iadr(adr, payment_id);
 	return tools::base58::encode_addr(integrated_address_prefix, t_serializable_object_to_blob(iadr));
 }
 

--- a/src/cryptonote_basic/cryptonote_stat_info.h
+++ b/src/cryptonote_basic/cryptonote_stat_info.h
@@ -57,7 +57,7 @@ struct core_stat_info
 	uint64_t alternative_blocks;
 	std::string top_block_id_str;
 
-	BEGIN_KV_SERIALIZE_MAP()
+	BEGIN_KV_SERIALIZE_MAP(core_stat_info)
 	KV_SERIALIZE(tx_pool_size)
 	KV_SERIALIZE(blockchain_height)
 	KV_SERIALIZE(mining_speed)

--- a/src/cryptonote_basic/miner.h
+++ b/src/cryptonote_basic/miner.h
@@ -131,7 +131,7 @@ class miner
 	{
 		uint64_t current_extra_message_index;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(miner_config)
 		KV_SERIALIZE(current_extra_message_index)
 		END_KV_SERIALIZE_MAP()
 	};

--- a/src/cryptonote_basic/subaddress_index.h
+++ b/src/cryptonote_basic/subaddress_index.h
@@ -53,6 +53,8 @@ namespace cryptonote
 {
 struct subaddress_index
 {
+	subaddress_index(uint32_t maj, uint32_t min) { major = maj; minor = min; }
+  
 	uint32_t major;
 	uint32_t minor;
 	bool operator==(const subaddress_index &rhs) const { return !memcmp(this, &rhs, sizeof(subaddress_index)); }
@@ -64,7 +66,7 @@ struct subaddress_index
 	FIELD(minor)
 	END_SERIALIZE()
 
-	BEGIN_KV_SERIALIZE_MAP()
+	BEGIN_KV_SERIALIZE_MAP(subaddress_index)
 	KV_SERIALIZE(major)
 	KV_SERIALIZE(minor)
 	END_KV_SERIALIZE_MAP()

--- a/src/cryptonote_core/cryptonote_tx_utils.cpp
+++ b/src/cryptonote_core/cryptonote_tx_utils.cpp
@@ -166,7 +166,7 @@ crypto::public_key get_destination_view_key_pub(const std::vector<tx_destination
 	if(allow_any_key && change_addr)
 		return change_addr->m_view_public_key;
 
-	account_public_address addr = {null_pkey, null_pkey};
+	account_public_address addr(null_pkey, null_pkey);
 	size_t count = 0;
 	for(const auto &i : destinations)
 	{

--- a/src/cryptonote_protocol/cryptonote_protocol_defs.h
+++ b/src/cryptonote_protocol/cryptonote_protocol_defs.h
@@ -93,7 +93,7 @@ struct connection_info
 
 	uint64_t height;
 
-	BEGIN_KV_SERIALIZE_MAP()
+	BEGIN_KV_SERIALIZE_MAP(connection_info)
 	KV_SERIALIZE(incoming)
 	KV_SERIALIZE(localhost)
 	KV_SERIALIZE(local_ip)
@@ -123,9 +123,11 @@ struct connection_info
 /************************************************************************/
 struct block_complete_entry
 {
+	block_complete_entry(blobdata block, std::list<blobdata> txs) : block(block), txs(txs)  {}
+
 	blobdata block;
 	std::list<blobdata> txs;
-	BEGIN_KV_SERIALIZE_MAP()
+	BEGIN_KV_SERIALIZE_MAP(block_complete_entry)
 	KV_SERIALIZE(block)
 	KV_SERIALIZE(txs)
 	END_KV_SERIALIZE_MAP()
@@ -143,7 +145,7 @@ struct NOTIFY_NEW_BLOCK
 		block_complete_entry b;
 		uint64_t current_blockchain_height;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(b)
 		KV_SERIALIZE(current_blockchain_height)
 		END_KV_SERIALIZE_MAP()
@@ -161,7 +163,7 @@ struct NOTIFY_NEW_TRANSACTIONS
 	{
 		std::list<blobdata> txs;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(txs)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -178,7 +180,7 @@ struct NOTIFY_REQUEST_GET_OBJECTS
 		std::list<crypto::hash> txs;
 		std::list<crypto::hash> blocks;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE_CONTAINER_POD_AS_BLOB(txs)
 		KV_SERIALIZE_CONTAINER_POD_AS_BLOB(blocks)
 		END_KV_SERIALIZE_MAP()
@@ -196,7 +198,7 @@ struct NOTIFY_RESPONSE_GET_OBJECTS
 		std::list<crypto::hash> missed_ids;
 		uint64_t current_blockchain_height;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(txs)
 		KV_SERIALIZE(blocks)
 		KV_SERIALIZE_CONTAINER_POD_AS_BLOB(missed_ids)
@@ -212,7 +214,7 @@ struct CORE_SYNC_DATA
 	crypto::hash top_id;
 	uint8_t top_version;
 
-	BEGIN_KV_SERIALIZE_MAP()
+	BEGIN_KV_SERIALIZE_MAP(CORE_SYNC_DATA)
 	KV_SERIALIZE(current_height)
 	KV_SERIALIZE(cumulative_difficulty)
 	KV_SERIALIZE_VAL_POD_AS_BLOB(top_id)
@@ -228,7 +230,7 @@ struct NOTIFY_REQUEST_CHAIN
 	{
 		std::list<crypto::hash> block_ids; /*IDs of the first 10 blocks are sequential, next goes with pow(2,n) offset, like 2, 4, 8, 16, 32, 64 and so on, and the last one is always genesis block */
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE_CONTAINER_POD_AS_BLOB(block_ids)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -245,7 +247,7 @@ struct NOTIFY_RESPONSE_CHAIN_ENTRY
 		uint64_t cumulative_difficulty;
 		std::list<crypto::hash> m_block_ids;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(start_height)
 		KV_SERIALIZE(total_height)
 		KV_SERIALIZE(cumulative_difficulty)
@@ -266,7 +268,7 @@ struct NOTIFY_NEW_FLUFFY_BLOCK
 		block_complete_entry b;
 		uint64_t current_blockchain_height;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(b)
 		KV_SERIALIZE(current_blockchain_height)
 		END_KV_SERIALIZE_MAP()
@@ -286,7 +288,7 @@ struct NOTIFY_REQUEST_FLUFFY_MISSING_TX
 		uint64_t current_blockchain_height;
 		std::vector<uint64_t> missing_tx_indices;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE_VAL_POD_AS_BLOB(block_hash)
 		KV_SERIALIZE(current_blockchain_height)
 		KV_SERIALIZE_CONTAINER_POD_AS_BLOB(missing_tx_indices)

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -1448,7 +1448,7 @@ bool t_rpc_command_executor::ban(const std::string &ip, time_t seconds)
 	std::string fail_message = "Unsuccessful";
 	epee::json_rpc::error error_resp;
 
-	cryptonote::COMMAND_RPC_SETBANS::ban ban;
+	cryptonote::COMMAND_RPC_SETBANS::ban_data ban;
 	if(!epee::string_tools::get_ip_int32_from_string(ban.ip, ip))
 	{
 		GULPS_PRINT_FAIL( "Invalid IP");
@@ -1484,7 +1484,7 @@ bool t_rpc_command_executor::unban(const std::string &ip)
 	std::string fail_message = "Unsuccessful";
 	epee::json_rpc::error error_resp;
 
-	cryptonote::COMMAND_RPC_SETBANS::ban ban;
+	cryptonote::COMMAND_RPC_SETBANS::ban_data ban;
 	if(!epee::string_tools::get_ip_int32_from_string(ban.ip, ip))
 	{
 		GULPS_PRINT_FAIL( "Invalid IP");

--- a/src/device/device_default.cpp
+++ b/src/device/device_default.cpp
@@ -177,7 +177,7 @@ std::vector<crypto::public_key> device_default::get_subaddress_spend_public_keys
 
 	std::vector<crypto::public_key> pkeys;
 	pkeys.reserve(end - begin);
-	cryptonote::subaddress_index index = {account, begin};
+	cryptonote::subaddress_index index(account, begin);
 
 	ge_p3 p3;
 	ge_cached cached;

--- a/src/p2p/net_node.h
+++ b/src/p2p/net_node.h
@@ -305,7 +305,7 @@ class node_server : public epee::levin::levin_commands_handler<p2p_connection_co
 		uint64_t m_peer_id;
 		uint32_t m_support_flags;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(config)
 		KV_SERIALIZE(m_net_config)
 		KV_SERIALIZE(m_peer_id)
 		KV_SERIALIZE(m_support_flags)

--- a/src/p2p/p2p_protocol_defs.h
+++ b/src/p2p/p2p_protocol_defs.h
@@ -80,10 +80,12 @@ static inline std::string peerid_to_string(peerid_type peer_id)
 
 struct network_address_old
 {
+	network_address_old(uint32_t ip, uint32_t port) : ip(ip), port(port)  {}
+
 	uint32_t ip;
 	uint32_t port;
 
-	BEGIN_KV_SERIALIZE_MAP()
+	BEGIN_KV_SERIALIZE_MAP(network_address_old)
 	KV_SERIALIZE(ip)
 	KV_SERIALIZE(port)
 	END_KV_SERIALIZE_MAP()
@@ -92,11 +94,13 @@ struct network_address_old
 template <typename AddressType>
 struct peerlist_entry_base
 {
+	peerlist_entry_base(AddressType adr, const peerid_type id, const int64_t last_seen) : adr(adr), id(id), last_seen(last_seen) {}
+  
 	AddressType adr;
 	peerid_type id;
 	int64_t last_seen;
 
-	BEGIN_KV_SERIALIZE_MAP()
+	BEGIN_KV_SERIALIZE_MAP(peerlist_entry_base)
 	KV_SERIALIZE(adr)
 	KV_SERIALIZE(id)
 	KV_SERIALIZE(last_seen)
@@ -111,7 +115,7 @@ struct anchor_peerlist_entry_base
 	peerid_type id;
 	int64_t first_seen;
 
-	BEGIN_KV_SERIALIZE_MAP()
+	BEGIN_KV_SERIALIZE_MAP(anchor_peerlist_entry_base)
 	KV_SERIALIZE(adr)
 	KV_SERIALIZE(id)
 	KV_SERIALIZE(first_seen)
@@ -126,7 +130,7 @@ struct connection_entry_base
 	peerid_type id;
 	bool is_income;
 
-	BEGIN_KV_SERIALIZE_MAP()
+	BEGIN_KV_SERIALIZE_MAP(connection_entry_base)
 	KV_SERIALIZE(adr)
 	KV_SERIALIZE(id)
 	KV_SERIALIZE(is_income)
@@ -151,7 +155,7 @@ inline std::string print_peerlist_to_string(const std::list<peerlist_entry> &pl)
 
 struct network_config
 {
-	BEGIN_KV_SERIALIZE_MAP()
+	BEGIN_KV_SERIALIZE_MAP(network_config)
 	KV_SERIALIZE(max_out_connection_count)
 	KV_SERIALIZE(max_in_connection_count)
 	KV_SERIALIZE(handshake_interval)
@@ -176,7 +180,7 @@ struct basic_node_data
 	uint32_t my_port;
 	peerid_type peer_id;
 
-	BEGIN_KV_SERIALIZE_MAP()
+	BEGIN_KV_SERIALIZE_MAP(basic_node_data)
 	KV_SERIALIZE_VAL_POD_AS_BLOB(network_id)
 	KV_SERIALIZE(peer_id)
 	KV_SERIALIZE(local_time)
@@ -199,7 +203,7 @@ struct COMMAND_HANDSHAKE_T
 		basic_node_data node_data;
 		t_playload_type payload_data;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(node_data)
 		KV_SERIALIZE(payload_data)
 		END_KV_SERIALIZE_MAP()
@@ -211,7 +215,7 @@ struct COMMAND_HANDSHAKE_T
 		t_playload_type payload_data;
 		std::list<peerlist_entry> local_peerlist_new;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(node_data)
 		KV_SERIALIZE(payload_data)
 		if(is_store)
@@ -258,7 +262,7 @@ struct COMMAND_TIMED_SYNC_T
 	struct request
 	{
 		t_playload_type payload_data;
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(payload_data)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -269,7 +273,7 @@ struct COMMAND_TIMED_SYNC_T
 		t_playload_type payload_data;
 		std::list<peerlist_entry> local_peerlist_new;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(local_time)
 		KV_SERIALIZE(payload_data)
 		if(is_store)
@@ -298,7 +302,7 @@ struct COMMAND_TIMED_SYNC_T
 				std::list<peerlist_entry_base<network_address_old>> local_peerlist;
 				epee::serialization::selector<is_store>::serialize_stl_container_pod_val_as_blob(local_peerlist, stg, hparent_section, "local_peerlist");
 				for(const auto &p : local_peerlist)
-					((response &)this_ref).local_peerlist_new.push_back(peerlist_entry({epee::net_utils::ipv4_network_address(p.adr.ip, p.adr.port), p.id, p.last_seen}));
+					((response &)this_ref).local_peerlist_new.push_back({epee::net_utils::ipv4_network_address(p.adr.ip, p.adr.port), p.id, p.last_seen});
 			}
 		}
 		END_KV_SERIALIZE_MAP()
@@ -324,7 +328,7 @@ struct COMMAND_PING
 	{
 		/*actually we don't need to send any real data*/
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		END_KV_SERIALIZE_MAP()
 	};
 
@@ -333,7 +337,7 @@ struct COMMAND_PING
 		std::string status;
 		peerid_type peer_id;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(status)
 		KV_SERIALIZE(peer_id)
 		END_KV_SERIALIZE_MAP()
@@ -350,7 +354,7 @@ struct proof_of_trust
 	uint64_t time;
 	crypto::signature sign;
 
-	BEGIN_KV_SERIALIZE_MAP()
+	BEGIN_KV_SERIALIZE_MAP(proof_of_trust)
 	KV_SERIALIZE(peer_id)
 	KV_SERIALIZE(time)
 	KV_SERIALIZE_VAL_POD_AS_BLOB(sign)
@@ -365,7 +369,7 @@ struct COMMAND_REQUEST_STAT_INFO_T
 	struct request
 	{
 		proof_of_trust tr;
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(tr)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -378,7 +382,7 @@ struct COMMAND_REQUEST_STAT_INFO_T
 		uint64_t incoming_connections_count;
 		payload_stat_info payload_info;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(version)
 		KV_SERIALIZE(os_version)
 		KV_SERIALIZE(connections_count)
@@ -398,7 +402,7 @@ struct COMMAND_REQUEST_NETWORK_STATE
 	struct request
 	{
 		proof_of_trust tr;
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(tr)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -410,7 +414,7 @@ struct COMMAND_REQUEST_NETWORK_STATE
 		std::list<connection_entry> connections_list;
 		peerid_type my_id;
 		uint64_t local_time;
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE_CONTAINER_POD_AS_BLOB(local_peerlist_white)
 		KV_SERIALIZE_CONTAINER_POD_AS_BLOB(local_peerlist_gray)
 		KV_SERIALIZE_CONTAINER_POD_AS_BLOB(connections_list)
@@ -429,7 +433,7 @@ struct COMMAND_REQUEST_PEER_ID
 
 	struct request
 	{
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		END_KV_SERIALIZE_MAP()
 	};
 
@@ -437,7 +441,7 @@ struct COMMAND_REQUEST_PEER_ID
 	{
 		peerid_type my_id;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(my_id)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -452,7 +456,7 @@ struct COMMAND_REQUEST_SUPPORT_FLAGS
 
 	struct request
 	{
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		END_KV_SERIALIZE_MAP()
 	};
 
@@ -460,7 +464,7 @@ struct COMMAND_REQUEST_SUPPORT_FLAGS
 	{
 		uint32_t support_flags;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(support_flags)
 		END_KV_SERIALIZE_MAP()
 	};

--- a/src/p2p/p2p_protocol_defs.h
+++ b/src/p2p/p2p_protocol_defs.h
@@ -61,7 +61,7 @@
 #include "crypto/crypto.h"
 #endif
 
-#include "common/gulps.hpp"	
+#include "common/gulps.hpp"
 
 
 namespace nodetool
@@ -95,7 +95,7 @@ template <typename AddressType>
 struct peerlist_entry_base
 {
 	peerlist_entry_base(AddressType adr, const peerid_type id, const int64_t last_seen) : adr(adr), id(id), last_seen(last_seen) {}
-  
+
 	AddressType adr;
 	peerid_type id;
 	int64_t last_seen;
@@ -302,7 +302,7 @@ struct COMMAND_TIMED_SYNC_T
 				std::list<peerlist_entry_base<network_address_old>> local_peerlist;
 				epee::serialization::selector<is_store>::serialize_stl_container_pod_val_as_blob(local_peerlist, stg, hparent_section, "local_peerlist");
 				for(const auto &p : local_peerlist)
-					((response &)this_ref).local_peerlist_new.push_back({epee::net_utils::ipv4_network_address(p.adr.ip, p.adr.port), p.id, p.last_seen});
+					((response &)this_ref).local_peerlist_new.emplace_back(peerlist_entry{epee::net_utils::ipv4_network_address(p.adr.ip, p.adr.port), p.id, p.last_seen});
 			}
 		}
 		END_KV_SERIALIZE_MAP()
@@ -316,7 +316,7 @@ struct COMMAND_TIMED_SYNC_T
 struct COMMAND_PING
 {
 	/*
-      Used to make "callback" connection, to be sure that opponent node 
+      Used to make "callback" connection, to be sure that opponent node
       have accessible connection point. Only other nodes can add peer to peerlist,
       and ONLY in case when peer has accepted connection and answered to ping.
     */

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -1825,7 +1825,7 @@ bool core_rpc_server::on_get_alternate_chains(const COMMAND_RPC_GET_ALTERNATE_CH
 		std::list<std::pair<Blockchain::block_extended_info, uint64_t>> chains = m_core.get_blockchain_storage().get_alternative_chains();
 		for(const auto &i : chains)
 		{
-			res.chains.push_back({epee::string_tools::pod_to_hex(get_block_hash(i.first.bl)), i.first.height,
+			res.chains.emplace_back(COMMAND_RPC_GET_ALTERNATE_CHAINS::chain_info{epee::string_tools::pod_to_hex(get_block_hash(i.first.bl)), i.first.height,
 					    i.second, i.first.cumulative_difficulty});
 		}
 		res.status = CORE_RPC_STATUS_OK;

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -1825,7 +1825,8 @@ bool core_rpc_server::on_get_alternate_chains(const COMMAND_RPC_GET_ALTERNATE_CH
 		std::list<std::pair<Blockchain::block_extended_info, uint64_t>> chains = m_core.get_blockchain_storage().get_alternative_chains();
 		for(const auto &i : chains)
 		{
-			res.chains.push_back(COMMAND_RPC_GET_ALTERNATE_CHAINS::chain_info{epee::string_tools::pod_to_hex(get_block_hash(i.first.bl)), i.first.height, i.second, i.first.cumulative_difficulty});
+			res.chains.push_back({epee::string_tools::pod_to_hex(get_block_hash(i.first.bl)), i.first.height,
+					    i.second, i.first.cumulative_difficulty});
 		}
 		res.status = CORE_RPC_STATUS_OK;
 	}

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -73,7 +73,7 @@ struct COMMAND_RPC_GET_HEIGHT
 {
 	struct request
 	{
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		END_KV_SERIALIZE_MAP()
 	};
 
@@ -83,7 +83,7 @@ struct COMMAND_RPC_GET_HEIGHT
 		std::string status;
 		bool untrusted;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(height)
 		KV_SERIALIZE(status)
 		KV_SERIALIZE(untrusted)
@@ -99,7 +99,7 @@ struct COMMAND_RPC_GET_BLOCKS_FAST
 		std::list<crypto::hash> block_ids; //*first 10 blocks id goes sequential, next goes in pow(2,n) offset, like 2, 4, 8, 16, 32, 64 and so on, and the last one is always genesis block */
 		uint64_t start_height;
 		bool prune;
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE_CONTAINER_POD_AS_BLOB(block_ids)
 		KV_SERIALIZE(start_height)
 		KV_SERIALIZE(prune)
@@ -110,7 +110,7 @@ struct COMMAND_RPC_GET_BLOCKS_FAST
 	{
 		std::vector<uint64_t> indices;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(tx_output_indices)
 		KV_SERIALIZE(indices)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -119,7 +119,7 @@ struct COMMAND_RPC_GET_BLOCKS_FAST
 	{
 		std::vector<tx_output_indices> indices;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(block_output_indices)
 		KV_SERIALIZE(indices)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -133,7 +133,7 @@ struct COMMAND_RPC_GET_BLOCKS_FAST
 		std::vector<block_output_indices> output_indices;
 		bool untrusted;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(blocks)
 		KV_SERIALIZE(start_height)
 		KV_SERIALIZE(current_height)
@@ -149,7 +149,7 @@ struct COMMAND_RPC_GET_BLOCKS_BY_HEIGHT
 	struct request
 	{
 		std::vector<uint64_t> heights;
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(heights)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -160,7 +160,7 @@ struct COMMAND_RPC_GET_BLOCKS_BY_HEIGHT
 		std::string status;
 		bool untrusted;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(blocks)
 		KV_SERIALIZE(status)
 		KV_SERIALIZE(untrusted)
@@ -172,7 +172,7 @@ struct COMMAND_RPC_GET_ALT_BLOCKS_HASHES
 {
 	struct request
 	{
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		END_KV_SERIALIZE_MAP()
 	};
 
@@ -182,7 +182,7 @@ struct COMMAND_RPC_GET_ALT_BLOCKS_HASHES
 		std::string status;
 		bool untrusted;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(blks_hashes)
 		KV_SERIALIZE(status)
 		KV_SERIALIZE(untrusted)
@@ -196,7 +196,7 @@ struct COMMAND_RPC_GET_HASHES_FAST
 	{
 		std::list<crypto::hash> block_ids; //*first 10 blocks id goes sequential, next goes in pow(2,n) offset, like 2, 4, 8, 16, 32, 64 and so on, and the last one is always genesis block */
 		uint64_t start_height;
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE_CONTAINER_POD_AS_BLOB(block_ids)
 		KV_SERIALIZE(start_height)
 		END_KV_SERIALIZE_MAP()
@@ -210,7 +210,7 @@ struct COMMAND_RPC_GET_HASHES_FAST
 		std::string status;
 		bool untrusted;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE_CONTAINER_POD_AS_BLOB(m_block_ids)
 		KV_SERIALIZE(start_height)
 		KV_SERIALIZE(current_height)
@@ -228,7 +228,7 @@ struct COMMAND_RPC_GET_ADDRESS_TXS
 		std::string address;
 		std::string view_key;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(address)
 		KV_SERIALIZE(view_key)
 		END_KV_SERIALIZE_MAP()
@@ -242,7 +242,7 @@ struct COMMAND_RPC_GET_ADDRESS_TXS
 		uint64_t out_index;
 		uint32_t mixin;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(spent_output)
 		KV_SERIALIZE(amount)
 		KV_SERIALIZE(key_image)
 		KV_SERIALIZE(tx_pub_key)
@@ -266,7 +266,7 @@ struct COMMAND_RPC_GET_ADDRESS_TXS
 		bool mempool;
 		uint32_t mixin;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(transaction)
 		KV_SERIALIZE(id)
 		KV_SERIALIZE(hash)
 		KV_SERIALIZE(timestamp)
@@ -292,7 +292,7 @@ struct COMMAND_RPC_GET_ADDRESS_TXS
 		uint64_t blockchain_height;
 		uint64_t scanned_block_height;
 		std::string status;
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(total_received)
 		KV_SERIALIZE(total_received_unlocked)
 		KV_SERIALIZE(scanned_height)
@@ -312,7 +312,7 @@ struct COMMAND_RPC_GET_ADDRESS_INFO
 		std::string address;
 		std::string view_key;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(address)
 		KV_SERIALIZE(view_key)
 		END_KV_SERIALIZE_MAP()
@@ -326,7 +326,7 @@ struct COMMAND_RPC_GET_ADDRESS_INFO
 		uint64_t out_index;
 		uint32_t mixin;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(spent_output)
 		KV_SERIALIZE(amount)
 		KV_SERIALIZE(key_image)
 		KV_SERIALIZE(tx_pub_key)
@@ -346,7 +346,7 @@ struct COMMAND_RPC_GET_ADDRESS_INFO
 		uint64_t transaction_height;
 		uint64_t blockchain_height;
 		std::list<spent_output> spent_outputs;
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(locked_funds)
 		KV_SERIALIZE(total_received)
 		KV_SERIALIZE(total_sent)
@@ -373,7 +373,7 @@ struct COMMAND_RPC_GET_UNSPENT_OUTS
 		bool use_dust;
 		std::string dust_threshold;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(amount)
 		KV_SERIALIZE(address)
 		KV_SERIALIZE(view_key)
@@ -397,7 +397,7 @@ struct COMMAND_RPC_GET_UNSPENT_OUTS
 		uint64_t timestamp;
 		uint64_t height;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(output)
 		KV_SERIALIZE(amount)
 		KV_SERIALIZE(public_key)
 		KV_SERIALIZE(index)
@@ -419,7 +419,7 @@ struct COMMAND_RPC_GET_UNSPENT_OUTS
 		uint64_t per_kb_fee;
 		std::string status;
 		std::string reason;
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(amount)
 		KV_SERIALIZE(outputs)
 		KV_SERIALIZE(per_kb_fee)
@@ -437,7 +437,7 @@ struct COMMAND_RPC_GET_RANDOM_OUTS
 		std::vector<std::string> amounts;
 		uint32_t count;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(amounts)
 		KV_SERIALIZE(count)
 		END_KV_SERIALIZE_MAP()
@@ -449,7 +449,7 @@ struct COMMAND_RPC_GET_RANDOM_OUTS
 		uint64_t global_index;
 		std::string rct; // 64+64+64 characters long (<rct commit> + <encrypted mask> + <rct amount>)
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(output)
 		KV_SERIALIZE(public_key)
 		KV_SERIALIZE(global_index)
 		KV_SERIALIZE(rct)
@@ -460,7 +460,7 @@ struct COMMAND_RPC_GET_RANDOM_OUTS
 	{
 		uint64_t amount;
 		std::vector<output> outputs;
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(amount_out)
 		KV_SERIALIZE(amount)
 		KV_SERIALIZE(outputs)
 		END_KV_SERIALIZE_MAP()
@@ -470,7 +470,7 @@ struct COMMAND_RPC_GET_RANDOM_OUTS
 	{
 		std::vector<amount_out> amount_outs;
 		std::string Error;
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(amount_outs)
 		KV_SERIALIZE(Error)
 		END_KV_SERIALIZE_MAP()
@@ -485,7 +485,7 @@ struct COMMAND_RPC_SUBMIT_RAW_TX
 		std::string view_key;
 		std::string tx;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(address)
 		KV_SERIALIZE(view_key)
 		KV_SERIALIZE(tx)
@@ -497,7 +497,7 @@ struct COMMAND_RPC_SUBMIT_RAW_TX
 		std::string status;
 		std::string error;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(status)
 		KV_SERIALIZE(error)
 		END_KV_SERIALIZE_MAP()
@@ -512,7 +512,7 @@ struct COMMAND_RPC_LOGIN
 		std::string view_key;
 		bool create_account;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(address)
 		KV_SERIALIZE(view_key)
 		KV_SERIALIZE(create_account)
@@ -525,7 +525,7 @@ struct COMMAND_RPC_LOGIN
 		std::string reason;
 		bool new_address;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(status)
 		KV_SERIALIZE(reason)
 		KV_SERIALIZE(new_address)
@@ -540,7 +540,7 @@ struct COMMAND_RPC_IMPORT_WALLET_REQUEST
 		std::string address;
 		std::string view_key;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(address)
 		KV_SERIALIZE(view_key)
 		END_KV_SERIALIZE_MAP()
@@ -555,7 +555,7 @@ struct COMMAND_RPC_IMPORT_WALLET_REQUEST
 		std::string payment_address;
 		std::string status;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(payment_id)
 		KV_SERIALIZE(import_fee)
 		KV_SERIALIZE(new_request)
@@ -574,7 +574,7 @@ struct COMMAND_RPC_GET_TRANSACTIONS
 		bool decode_as_json;
 		bool prune;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(txs_hashes)
 		KV_SERIALIZE(decode_as_json)
 		KV_SERIALIZE_OPT(prune, false)
@@ -592,7 +592,7 @@ struct COMMAND_RPC_GET_TRANSACTIONS
 		uint64_t block_timestamp;
 		std::vector<uint64_t> output_indices;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(entry)
 		KV_SERIALIZE(tx_hash)
 		KV_SERIALIZE(as_hex)
 		KV_SERIALIZE(as_json)
@@ -618,7 +618,7 @@ struct COMMAND_RPC_GET_TRANSACTIONS
 		std::string status;
 		bool untrusted;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(txs_as_hex)
 		KV_SERIALIZE(txs_as_json)
 		KV_SERIALIZE(txs)
@@ -643,7 +643,7 @@ struct COMMAND_RPC_IS_KEY_IMAGE_SPENT
 	{
 		std::vector<std::string> key_images;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(key_images)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -654,7 +654,7 @@ struct COMMAND_RPC_IS_KEY_IMAGE_SPENT
 		std::string status;
 		bool untrusted;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(spent_status)
 		KV_SERIALIZE(status)
 		KV_SERIALIZE(untrusted)
@@ -668,7 +668,7 @@ struct COMMAND_RPC_GET_TX_GLOBAL_OUTPUTS_INDEXES
 	struct request
 	{
 		crypto::hash txid;
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE_VAL_POD_AS_BLOB(txid)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -678,7 +678,7 @@ struct COMMAND_RPC_GET_TX_GLOBAL_OUTPUTS_INDEXES
 		std::vector<uint64_t> o_indexes;
 		std::string status;
 		bool untrusted;
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(o_indexes)
 		KV_SERIALIZE(status)
 		KV_SERIALIZE(untrusted)
@@ -692,7 +692,7 @@ struct COMMAND_RPC_GET_RANDOM_OUTPUTS_FOR_AMOUNTS
 	{
 		std::vector<uint64_t> amounts;
 		uint64_t outs_count;
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(amounts)
 		KV_SERIALIZE(outs_count)
 		END_KV_SERIALIZE_MAP()
@@ -711,7 +711,7 @@ struct COMMAND_RPC_GET_RANDOM_OUTPUTS_FOR_AMOUNTS
 		uint64_t amount;
 		std::list<out_entry> outs;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(outs_for_amount)
 		KV_SERIALIZE(amount)
 		KV_SERIALIZE_CONTAINER_POD_AS_BLOB(outs)
 		END_KV_SERIALIZE_MAP()
@@ -722,7 +722,7 @@ struct COMMAND_RPC_GET_RANDOM_OUTPUTS_FOR_AMOUNTS
 		std::vector<outs_for_amount> outs;
 		std::string status;
 		bool untrusted;
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(outs)
 		KV_SERIALIZE(status)
 		KV_SERIALIZE(untrusted)
@@ -732,10 +732,12 @@ struct COMMAND_RPC_GET_RANDOM_OUTPUTS_FOR_AMOUNTS
 //-----------------------------------------------
 struct get_outputs_out
 {
+	get_outputs_out(uint64_t amount, uint64_t index) : amount(amount), index(index) {}
+  
 	uint64_t amount;
 	uint64_t index;
 
-	BEGIN_KV_SERIALIZE_MAP()
+	BEGIN_KV_SERIALIZE_MAP(get_outputs_out)
 	KV_SERIALIZE(amount)
 	KV_SERIALIZE(index)
 	END_KV_SERIALIZE_MAP()
@@ -747,20 +749,23 @@ struct COMMAND_RPC_GET_OUTPUTS_BIN
 	{
 		std::vector<get_outputs_out> outputs;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(outputs)
 		END_KV_SERIALIZE_MAP()
 	};
 
 	struct outkey
 	{
+		outkey(crypto::public_key key, rct::key mask, bool unlocked, uint64_t height, crypto::hash txid) : key(key), mask(mask),
+			unlocked(unlocked), height(height), txid(txid)  {}
+	  
 		crypto::public_key key;
 		rct::key mask;
 		bool unlocked;
 		uint64_t height;
 		crypto::hash txid;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(outkey)
 		KV_SERIALIZE_VAL_POD_AS_BLOB(key)
 		KV_SERIALIZE_VAL_POD_AS_BLOB(mask)
 		KV_SERIALIZE(unlocked)
@@ -775,7 +780,7 @@ struct COMMAND_RPC_GET_OUTPUTS_BIN
 		std::string status;
 		bool untrusted;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(outs)
 		KV_SERIALIZE(status)
 		KV_SERIALIZE(untrusted)
@@ -789,7 +794,7 @@ struct COMMAND_RPC_GET_OUTPUTS
 	{
 		std::vector<get_outputs_out> outputs;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(outputs)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -802,7 +807,7 @@ struct COMMAND_RPC_GET_OUTPUTS
 		uint64_t height;
 		std::string txid;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(outkey)
 		KV_SERIALIZE(key)
 		KV_SERIALIZE(mask)
 		KV_SERIALIZE(unlocked)
@@ -817,7 +822,7 @@ struct COMMAND_RPC_GET_OUTPUTS
 		std::string status;
 		bool untrusted;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(outs)
 		KV_SERIALIZE(status)
 		KV_SERIALIZE(untrusted)
@@ -830,7 +835,7 @@ struct COMMAND_RPC_GET_RANDOM_RCT_OUTPUTS
 	struct request
 	{
 		uint64_t outs_count;
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(outs_count)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -850,7 +855,7 @@ struct COMMAND_RPC_GET_RANDOM_RCT_OUTPUTS
 		std::list<out_entry> outs;
 		std::string status;
 		bool untrusted;
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE_CONTAINER_POD_AS_BLOB(outs)
 		KV_SERIALIZE(status)
 		KV_SERIALIZE(untrusted)
@@ -865,10 +870,9 @@ struct COMMAND_RPC_SEND_RAW_TX
 		std::string tx_as_hex;
 		bool do_not_relay;
 
-		request() {}
 		explicit request(const transaction &);
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(tx_as_hex)
 		KV_SERIALIZE_OPT(do_not_relay, false)
 		END_KV_SERIALIZE_MAP()
@@ -889,7 +893,7 @@ struct COMMAND_RPC_SEND_RAW_TX
 		bool not_rct;
 		bool untrusted;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(status)
 		KV_SERIALIZE(reason)
 		KV_SERIALIZE(not_relayed)
@@ -915,7 +919,7 @@ struct COMMAND_RPC_START_MINING
 		bool do_background_mining;
 		bool ignore_battery;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(miner_address)
 		KV_SERIALIZE(threads_count)
 		KV_SERIALIZE(do_background_mining)
@@ -927,7 +931,7 @@ struct COMMAND_RPC_START_MINING
 	{
 		std::string status;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(status)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -938,7 +942,7 @@ struct COMMAND_RPC_GET_INFO
 	struct request
 	{
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		END_KV_SERIALIZE_MAP()
 	};
 
@@ -973,7 +977,7 @@ struct COMMAND_RPC_GET_INFO
 		uint64_t height_without_bootstrap;
 		bool was_bootstrap_ever_used;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(status)
 		KV_SERIALIZE(height)
 		KV_SERIALIZE(target_height)
@@ -1012,7 +1016,7 @@ struct COMMAND_RPC_STOP_MINING
 	struct request
 	{
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		END_KV_SERIALIZE_MAP()
 	};
 
@@ -1020,7 +1024,7 @@ struct COMMAND_RPC_STOP_MINING
 	{
 		std::string status;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(status)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -1032,7 +1036,7 @@ struct COMMAND_RPC_MINING_STATUS
 	struct request
 	{
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		END_KV_SERIALIZE_MAP()
 	};
 
@@ -1045,7 +1049,7 @@ struct COMMAND_RPC_MINING_STATUS
 		std::string address;
 		bool is_background_mining_enabled;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(status)
 		KV_SERIALIZE(active)
 		KV_SERIALIZE(speed)
@@ -1062,7 +1066,7 @@ struct COMMAND_RPC_SAVE_BC
 	struct request
 	{
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		END_KV_SERIALIZE_MAP()
 	};
 
@@ -1070,7 +1074,7 @@ struct COMMAND_RPC_SAVE_BC
 	{
 		std::string status;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(status)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -1086,7 +1090,7 @@ struct COMMAND_RPC_GETBLOCKCOUNT
 		uint64_t count;
 		std::string status;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(count)
 		KV_SERIALIZE(status)
 		END_KV_SERIALIZE_MAP()
@@ -1107,7 +1111,7 @@ struct COMMAND_RPC_GETBLOCKTEMPLATE
 		uint64_t reserve_size; //max 255 bytes
 		std::string wallet_address;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(reserve_size)
 		KV_SERIALIZE(wallet_address)
 		END_KV_SERIALIZE_MAP()
@@ -1125,7 +1129,7 @@ struct COMMAND_RPC_GETBLOCKTEMPLATE
 		std::string status;
 		bool untrusted;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(difficulty)
 		KV_SERIALIZE(height)
 		KV_SERIALIZE(reserved_offset)
@@ -1147,7 +1151,7 @@ struct COMMAND_RPC_SUBMITBLOCK
 	{
 		std::string status;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(status)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -1169,7 +1173,7 @@ struct block_header_response
 	uint64_t block_size;
 	uint64_t num_txes;
 
-	BEGIN_KV_SERIALIZE_MAP()
+	BEGIN_KV_SERIALIZE_MAP(block_header_response)
 	KV_SERIALIZE(major_version)
 	KV_SERIALIZE(minor_version)
 	KV_SERIALIZE(timestamp)
@@ -1190,7 +1194,7 @@ struct COMMAND_RPC_GET_LAST_BLOCK_HEADER
 {
 	struct request
 	{
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		END_KV_SERIALIZE_MAP()
 	};
 
@@ -1200,7 +1204,7 @@ struct COMMAND_RPC_GET_LAST_BLOCK_HEADER
 		block_header_response block_header;
 		bool untrusted;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(block_header)
 		KV_SERIALIZE(status)
 		KV_SERIALIZE(untrusted)
@@ -1214,7 +1218,7 @@ struct COMMAND_RPC_GET_BLOCK_HEADER_BY_HASH
 	{
 		std::string hash;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(hash)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -1225,7 +1229,7 @@ struct COMMAND_RPC_GET_BLOCK_HEADER_BY_HASH
 		block_header_response block_header;
 		bool untrusted;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(block_header)
 		KV_SERIALIZE(status)
 		KV_SERIALIZE(untrusted)
@@ -1239,7 +1243,7 @@ struct COMMAND_RPC_GET_BLOCK_HEADER_BY_HEIGHT
 	{
 		uint64_t height;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(height)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -1250,7 +1254,7 @@ struct COMMAND_RPC_GET_BLOCK_HEADER_BY_HEIGHT
 		block_header_response block_header;
 		bool untrusted;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(block_header)
 		KV_SERIALIZE(status)
 		KV_SERIALIZE(untrusted)
@@ -1265,7 +1269,7 @@ struct COMMAND_RPC_GET_BLOCK
 		std::string hash;
 		uint64_t height;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(hash)
 		KV_SERIALIZE(height)
 		END_KV_SERIALIZE_MAP()
@@ -1281,7 +1285,7 @@ struct COMMAND_RPC_GET_BLOCK
 		std::string json;
 		bool untrusted;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(block_header)
 		KV_SERIALIZE(miner_tx_hash)
 		KV_SERIALIZE(tx_hashes)
@@ -1301,8 +1305,6 @@ struct peer
 	uint16_t port;
 	uint64_t last_seen;
 
-	peer() = default;
-
 	peer(uint64_t id, const std::string &host, uint64_t last_seen)
 		: id(id), host(host), ip(0), port(0), last_seen(last_seen)
 	{
@@ -1312,7 +1314,7 @@ struct peer
 	{
 	}
 
-	BEGIN_KV_SERIALIZE_MAP()
+	BEGIN_KV_SERIALIZE_MAP(peer)
 	KV_SERIALIZE(id)
 	KV_SERIALIZE(host)
 	KV_SERIALIZE(ip)
@@ -1325,7 +1327,7 @@ struct COMMAND_RPC_GET_PEER_LIST
 {
 	struct request
 	{
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		END_KV_SERIALIZE_MAP()
 	};
 
@@ -1335,7 +1337,7 @@ struct COMMAND_RPC_GET_PEER_LIST
 		std::vector<peer> white_list;
 		std::vector<peer> gray_list;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(status)
 		KV_SERIALIZE(white_list)
 		KV_SERIALIZE(gray_list)
@@ -1349,7 +1351,7 @@ struct COMMAND_RPC_SET_LOG_HASH_RATE
 	{
 		bool visible;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(visible)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -1357,7 +1359,7 @@ struct COMMAND_RPC_SET_LOG_HASH_RATE
 	struct response
 	{
 		std::string status;
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(status)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -1369,7 +1371,7 @@ struct COMMAND_RPC_SET_LOG_LEVEL
 	{
 		int8_t level;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(level)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -1377,7 +1379,7 @@ struct COMMAND_RPC_SET_LOG_LEVEL
 	struct response
 	{
 		std::string status;
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(status)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -1389,7 +1391,7 @@ struct COMMAND_RPC_SET_LOG_CATEGORIES
 	{
 		std::string categories;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(categories)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -1399,7 +1401,7 @@ struct COMMAND_RPC_SET_LOG_CATEGORIES
 		std::string status;
 		std::string categories;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(status)
 		KV_SERIALIZE(categories)
 		END_KV_SERIALIZE_MAP()
@@ -1424,7 +1426,7 @@ struct tx_info
 	bool double_spend_seen;
 	std::string tx_blob;
 
-	BEGIN_KV_SERIALIZE_MAP()
+	BEGIN_KV_SERIALIZE_MAP(tx_info)
 	KV_SERIALIZE(id_hash)
 	KV_SERIALIZE(tx_json)
 	KV_SERIALIZE(blob_size)
@@ -1448,7 +1450,7 @@ struct spent_key_image_info
 	std::string id_hash;
 	std::vector<std::string> txs_hashes;
 
-	BEGIN_KV_SERIALIZE_MAP()
+	BEGIN_KV_SERIALIZE_MAP(spent_key_image_info)
 	KV_SERIALIZE(id_hash)
 	KV_SERIALIZE(txs_hashes)
 	END_KV_SERIALIZE_MAP()
@@ -1458,7 +1460,7 @@ struct COMMAND_RPC_GET_TRANSACTION_POOL
 {
 	struct request
 	{
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		END_KV_SERIALIZE_MAP()
 	};
 
@@ -1469,7 +1471,7 @@ struct COMMAND_RPC_GET_TRANSACTION_POOL
 		std::vector<spent_key_image_info> spent_key_images;
 		bool untrusted;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(status)
 		KV_SERIALIZE(transactions)
 		KV_SERIALIZE(spent_key_images)
@@ -1482,7 +1484,7 @@ struct COMMAND_RPC_GET_TRANSACTION_POOL_HASHES
 {
 	struct request
 	{
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		END_KV_SERIALIZE_MAP()
 	};
 
@@ -1492,7 +1494,7 @@ struct COMMAND_RPC_GET_TRANSACTION_POOL_HASHES
 		std::vector<crypto::hash> tx_hashes;
 		bool untrusted;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(status)
 		KV_SERIALIZE_CONTAINER_POD_AS_BLOB(tx_hashes)
 		KV_SERIALIZE(untrusted)
@@ -1511,7 +1513,7 @@ struct COMMAND_RPC_GET_TRANSACTION_POOL_BACKLOG
 {
 	struct request
 	{
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		END_KV_SERIALIZE_MAP()
 	};
 
@@ -1521,7 +1523,7 @@ struct COMMAND_RPC_GET_TRANSACTION_POOL_BACKLOG
 		std::vector<tx_backlog_entry> backlog;
 		bool untrusted;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(status)
 		KV_SERIALIZE_CONTAINER_POD_AS_BLOB(backlog)
 		KV_SERIALIZE(untrusted)
@@ -1534,7 +1536,7 @@ struct txpool_histo
 	uint32_t txs;
 	uint64_t bytes;
 
-	BEGIN_KV_SERIALIZE_MAP()
+	BEGIN_KV_SERIALIZE_MAP(txpool_histo)
 	KV_SERIALIZE(txs)
 	KV_SERIALIZE(bytes)
 	END_KV_SERIALIZE_MAP()
@@ -1573,7 +1575,7 @@ struct txpool_stats
 		num_double_spends = 0;
 	}
 
-	BEGIN_KV_SERIALIZE_MAP()
+	BEGIN_KV_SERIALIZE_MAP(txpool_stats)
 	KV_SERIALIZE(bytes_total)
 	KV_SERIALIZE(bytes_min)
 	KV_SERIALIZE(bytes_max)
@@ -1594,7 +1596,7 @@ struct COMMAND_RPC_GET_TRANSACTION_POOL_STATS
 {
 	struct request
 	{
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		END_KV_SERIALIZE_MAP()
 	};
 
@@ -1604,7 +1606,7 @@ struct COMMAND_RPC_GET_TRANSACTION_POOL_STATS
 		txpool_stats pool_stats;
 		bool untrusted;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(status)
 		KV_SERIALIZE(pool_stats)
 		KV_SERIALIZE(untrusted)
@@ -1616,7 +1618,7 @@ struct COMMAND_RPC_GET_CONNECTIONS
 {
 	struct request
 	{
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		END_KV_SERIALIZE_MAP()
 	};
 
@@ -1625,7 +1627,7 @@ struct COMMAND_RPC_GET_CONNECTIONS
 		std::string status;
 		std::list<connection_info> connections;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(status)
 		KV_SERIALIZE(connections)
 		END_KV_SERIALIZE_MAP()
@@ -1639,7 +1641,7 @@ struct COMMAND_RPC_GET_BLOCK_HEADERS_RANGE
 		uint64_t start_height;
 		uint64_t end_height;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(start_height)
 		KV_SERIALIZE(end_height)
 		END_KV_SERIALIZE_MAP()
@@ -1651,7 +1653,7 @@ struct COMMAND_RPC_GET_BLOCK_HEADERS_RANGE
 		std::vector<block_header_response> headers;
 		bool untrusted;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(status)
 		KV_SERIALIZE(headers)
 		KV_SERIALIZE(untrusted)
@@ -1663,7 +1665,7 @@ struct COMMAND_RPC_STOP_DAEMON
 {
 	struct request
 	{
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		END_KV_SERIALIZE_MAP()
 	};
 
@@ -1671,7 +1673,7 @@ struct COMMAND_RPC_STOP_DAEMON
 	{
 		std::string status;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(status)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -1681,7 +1683,7 @@ struct COMMAND_RPC_FAST_EXIT
 {
 	struct request
 	{
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		END_KV_SERIALIZE_MAP()
 	};
 
@@ -1689,7 +1691,7 @@ struct COMMAND_RPC_FAST_EXIT
 	{
 		std::string status;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(status)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -1699,7 +1701,7 @@ struct COMMAND_RPC_GET_LIMIT
 {
 	struct request
 	{
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		END_KV_SERIALIZE_MAP()
 	};
 
@@ -1710,7 +1712,7 @@ struct COMMAND_RPC_GET_LIMIT
 		uint64_t limit_down;
 		bool untrusted;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(status)
 		KV_SERIALIZE(limit_up)
 		KV_SERIALIZE(limit_down)
@@ -1726,7 +1728,7 @@ struct COMMAND_RPC_SET_LIMIT
 		int64_t limit_down; // all limits (for get and set) are kB/s
 		int64_t limit_up;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(limit_down)
 		KV_SERIALIZE(limit_up)
 		END_KV_SERIALIZE_MAP()
@@ -1738,7 +1740,7 @@ struct COMMAND_RPC_SET_LIMIT
 		int64_t limit_up;
 		int64_t limit_down;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(status)
 		KV_SERIALIZE(limit_up)
 		KV_SERIALIZE(limit_down)
@@ -1751,7 +1753,7 @@ struct COMMAND_RPC_OUT_PEERS
 	struct request
 	{
 		uint64_t out_peers;
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(out_peers)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -1760,7 +1762,7 @@ struct COMMAND_RPC_OUT_PEERS
 	{
 		std::string status;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(status)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -1771,7 +1773,7 @@ struct COMMAND_RPC_IN_PEERS
 	struct request
 	{
 		uint64_t in_peers;
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(in_peers)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -1780,7 +1782,7 @@ struct COMMAND_RPC_IN_PEERS
 	{
 		std::string status;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(status)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -1792,7 +1794,7 @@ struct COMMAND_RPC_HARD_FORK_INFO
 	{
 		uint8_t version;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(version)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -1810,7 +1812,7 @@ struct COMMAND_RPC_HARD_FORK_INFO
 		std::string status;
 		bool untrusted;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(version)
 		KV_SERIALIZE(enabled)
 		KV_SERIALIZE(window)
@@ -1833,7 +1835,7 @@ struct COMMAND_RPC_GETBANS
 		uint32_t ip;
 		uint32_t seconds;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(ban)
 		KV_SERIALIZE(host)
 		KV_SERIALIZE(ip)
 		KV_SERIALIZE(seconds)
@@ -1842,7 +1844,7 @@ struct COMMAND_RPC_GETBANS
 
 	struct request
 	{
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		END_KV_SERIALIZE_MAP()
 	};
 
@@ -1851,7 +1853,7 @@ struct COMMAND_RPC_GETBANS
 		std::string status;
 		std::vector<ban> bans;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(status)
 		KV_SERIALIZE(bans)
 		END_KV_SERIALIZE_MAP()
@@ -1860,14 +1862,14 @@ struct COMMAND_RPC_GETBANS
 
 struct COMMAND_RPC_SETBANS
 {
-	struct ban
+	struct ban_data
 	{
 		std::string host;
 		uint32_t ip;
 		bool ban;
 		uint32_t seconds;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(ban_data)
 		KV_SERIALIZE(host)
 		KV_SERIALIZE(ip)
 		KV_SERIALIZE(ban)
@@ -1877,9 +1879,9 @@ struct COMMAND_RPC_SETBANS
 
 	struct request
 	{
-		std::vector<ban> bans;
+		std::vector<ban_data> bans;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(bans)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -1888,7 +1890,7 @@ struct COMMAND_RPC_SETBANS
 	{
 		std::string status;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(status)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -1900,7 +1902,7 @@ struct COMMAND_RPC_FLUSH_TRANSACTION_POOL
 	{
 		std::list<std::string> txids;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(txids)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -1909,7 +1911,7 @@ struct COMMAND_RPC_FLUSH_TRANSACTION_POOL
 	{
 		std::string status;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(status)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -1925,7 +1927,7 @@ struct COMMAND_RPC_GET_OUTPUT_HISTOGRAM
 		bool unlocked;
 		uint64_t recent_cutoff;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(amounts);
 		KV_SERIALIZE(min_count);
 		KV_SERIALIZE(max_count);
@@ -1941,7 +1943,7 @@ struct COMMAND_RPC_GET_OUTPUT_HISTOGRAM
 		uint64_t unlocked_instances;
 		uint64_t recent_instances;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(entry)
 		KV_SERIALIZE(amount);
 		KV_SERIALIZE(total_instances);
 		KV_SERIALIZE(unlocked_instances);
@@ -1949,7 +1951,6 @@ struct COMMAND_RPC_GET_OUTPUT_HISTOGRAM
 		END_KV_SERIALIZE_MAP()
 
 		entry(uint64_t amount, uint64_t total_instances, uint64_t unlocked_instances, uint64_t recent_instances) : amount(amount), total_instances(total_instances), unlocked_instances(unlocked_instances), recent_instances(recent_instances) {}
-		entry() {}
 	};
 
 	struct response
@@ -1958,7 +1959,7 @@ struct COMMAND_RPC_GET_OUTPUT_HISTOGRAM
 		std::vector<entry> histogram;
 		bool untrusted;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(status)
 		KV_SERIALIZE(histogram)
 		KV_SERIALIZE(untrusted)
@@ -1970,7 +1971,7 @@ struct COMMAND_RPC_GET_VERSION
 {
 	struct request
 	{
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		END_KV_SERIALIZE_MAP()
 	};
 
@@ -1980,7 +1981,7 @@ struct COMMAND_RPC_GET_VERSION
 		uint32_t version;
 		bool untrusted;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(status)
 		KV_SERIALIZE(version)
 		KV_SERIALIZE(untrusted)
@@ -1995,7 +1996,7 @@ struct COMMAND_RPC_GET_COINBASE_TX_SUM
 		uint64_t height;
 		uint64_t count;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(height);
 		KV_SERIALIZE(count);
 		END_KV_SERIALIZE_MAP()
@@ -2007,7 +2008,7 @@ struct COMMAND_RPC_GET_COINBASE_TX_SUM
 		uint64_t emission_amount;
 		uint64_t fee_amount;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(status)
 		KV_SERIALIZE(emission_amount)
 		KV_SERIALIZE(fee_amount)
@@ -2019,18 +2020,20 @@ struct COMMAND_RPC_GET_ALTERNATE_CHAINS
 {
 	struct request
 	{
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		END_KV_SERIALIZE_MAP()
 	};
 
 	struct chain_info
 	{
+		chain_info(std::string block_hash, const uint64_t height, const uint64_t length, const uint64_t difficulty) : block_hash(block_hash), height(height), length(length), difficulty(difficulty) {}
+
 		std::string block_hash;
 		uint64_t height;
 		uint64_t length;
 		uint64_t difficulty;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(chain_info)
 		KV_SERIALIZE(block_hash)
 		KV_SERIALIZE(height)
 		KV_SERIALIZE(length)
@@ -2043,7 +2046,7 @@ struct COMMAND_RPC_GET_ALTERNATE_CHAINS
 		std::string status;
 		std::list<chain_info> chains;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(status)
 		KV_SERIALIZE(chains)
 		END_KV_SERIALIZE_MAP()
@@ -2057,7 +2060,7 @@ struct COMMAND_RPC_UPDATE
 		std::string command;
 		std::string path;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(command);
 		KV_SERIALIZE(path);
 		END_KV_SERIALIZE_MAP()
@@ -2073,7 +2076,7 @@ struct COMMAND_RPC_UPDATE
 		std::string hash;
 		std::string path;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(status)
 		KV_SERIALIZE(update)
 		KV_SERIALIZE(version)
@@ -2091,7 +2094,7 @@ struct COMMAND_RPC_RELAY_TX
 	{
 		std::list<std::string> txids;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(txids)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -2100,7 +2103,7 @@ struct COMMAND_RPC_RELAY_TX
 	{
 		std::string status;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(status)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -2110,21 +2113,26 @@ struct COMMAND_RPC_SYNC_INFO
 {
 	struct request
 	{
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		END_KV_SERIALIZE_MAP()
 	};
 
 	struct peer
 	{
+		peer(connection_info info) : info(info) {}
+
 		connection_info info;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(peer)
 		KV_SERIALIZE(info)
 		END_KV_SERIALIZE_MAP()
 	};
 
 	struct span
 	{
+		span(uint64_t start_block_height, uint64_t nblocks, std::string connection_id, uint32_t rate, uint32_t speed, uint64_t size, std::string remote_address) :
+		    start_block_height(start_block_height), nblocks(nblocks), connection_id(connection_id), rate(rate), speed(speed), size(size), remote_address(remote_address)  {}
+	  
 		uint64_t start_block_height;
 		uint64_t nblocks;
 		std::string connection_id;
@@ -2133,7 +2141,7 @@ struct COMMAND_RPC_SYNC_INFO
 		uint64_t size;
 		std::string remote_address;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(span)
 		KV_SERIALIZE(start_block_height)
 		KV_SERIALIZE(nblocks)
 		KV_SERIALIZE(connection_id)
@@ -2152,7 +2160,7 @@ struct COMMAND_RPC_SYNC_INFO
 		std::list<peer> peers;
 		std::list<span> spans;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(status)
 		KV_SERIALIZE(height)
 		KV_SERIALIZE(target_height)
@@ -2171,7 +2179,7 @@ struct COMMAND_RPC_GET_OUTPUT_DISTRIBUTION
 		uint64_t to_height;
 		bool cumulative;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(amounts)
 		KV_SERIALIZE_OPT(from_height, (uint64_t)0)
 		KV_SERIALIZE_OPT(to_height, (uint64_t)0)
@@ -2179,14 +2187,16 @@ struct COMMAND_RPC_GET_OUTPUT_DISTRIBUTION
 		END_KV_SERIALIZE_MAP()
 	};
 
-	struct distribution
+	struct distribution_data
 	{
+		distribution_data(uint64_t amount, uint64_t start_height, std::vector<uint64_t> distribution, uint64_t base) :
+				  amount(amount), start_height(start_height), distribution(distribution), base(base) {}
 		uint64_t amount;
 		uint64_t start_height;
 		std::vector<uint64_t> distribution;
 		uint64_t base;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(distribution_data)
 		KV_SERIALIZE(amount)
 		KV_SERIALIZE(start_height)
 		KV_SERIALIZE_CONTAINER_POD_AS_BLOB(distribution)
@@ -2197,9 +2207,9 @@ struct COMMAND_RPC_GET_OUTPUT_DISTRIBUTION
 	struct response
 	{
 		std::string status;
-		std::vector<distribution> distributions;
+		std::vector<distribution_data> distributions;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(status)
 		KV_SERIALIZE(distributions)
 		END_KV_SERIALIZE_MAP()

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -2032,7 +2032,7 @@ bool wallet_rpc_server::on_get_address_book(const wallet_rpc::COMMAND_RPC_GET_AD
 	{
 		uint64_t idx = 0;
 		for(const auto &entry : ab)
-			res.entries.push_back(wallet_rpc::COMMAND_RPC_GET_ADDRESS_BOOK_ENTRY::entry{idx++, get_public_address_as_str(m_wallet->nettype(), entry.m_is_subaddress, entry.m_address), epee::string_tools::pod_to_hex(entry.m_payment_id), entry.m_description});
+			res.entries.push_back({idx++, get_public_address_as_str(m_wallet->nettype(), entry.m_is_subaddress, entry.m_address), epee::string_tools::pod_to_hex(entry.m_payment_id), entry.m_description});
 	}
 	else
 	{
@@ -2045,7 +2045,7 @@ bool wallet_rpc_server::on_get_address_book(const wallet_rpc::COMMAND_RPC_GET_AD
 				return false;
 			}
 			const auto &entry = ab[idx];
-			res.entries.push_back(wallet_rpc::COMMAND_RPC_GET_ADDRESS_BOOK_ENTRY::entry{idx, get_public_address_as_str(m_wallet->nettype(), entry.m_is_subaddress, entry.m_address), epee::string_tools::pod_to_hex(entry.m_payment_id), entry.m_description});
+			res.entries.push_back({idx, get_public_address_as_str(m_wallet->nettype(), entry.m_is_subaddress, entry.m_address), epee::string_tools::pod_to_hex(entry.m_payment_id), entry.m_description});
 		}
 	}
 	return true;

--- a/src/wallet/wallet_rpc_server_commands_defs.h
+++ b/src/wallet/wallet_rpc_server_commands_defs.h
@@ -66,7 +66,7 @@ struct COMMAND_RPC_GET_BALANCE
 	struct request
 	{
 		uint32_t account_index;
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(account_index)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -80,7 +80,7 @@ struct COMMAND_RPC_GET_BALANCE
 		std::string label;
 		uint64_t num_unspent_outputs;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(per_subaddress_info)
 		KV_SERIALIZE(address_index)
 		KV_SERIALIZE(address)
 		KV_SERIALIZE(balance)
@@ -97,7 +97,7 @@ struct COMMAND_RPC_GET_BALANCE
 		bool multisig_import_needed;
 		std::vector<per_subaddress_info> per_subaddress;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(balance)
 		KV_SERIALIZE(unlocked_balance)
 		KV_SERIALIZE(multisig_import_needed)
@@ -112,7 +112,7 @@ struct COMMAND_RPC_GET_ADDRESS
 	{
 		uint32_t account_index;
 		std::vector<uint32_t> address_index;
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(account_index)
 		KV_SERIALIZE(address_index)
 		END_KV_SERIALIZE_MAP()
@@ -125,7 +125,7 @@ struct COMMAND_RPC_GET_ADDRESS
 		uint32_t address_index;
 		bool used;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(address_info)
 		KV_SERIALIZE(address)
 		KV_SERIALIZE(label)
 		KV_SERIALIZE(address_index)
@@ -138,7 +138,7 @@ struct COMMAND_RPC_GET_ADDRESS
 		std::string address; // to remain compatible with older RPC format
 		std::vector<address_info> addresses;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(address)
 		KV_SERIALIZE(addresses)
 		END_KV_SERIALIZE_MAP()
@@ -152,7 +152,7 @@ struct COMMAND_RPC_CREATE_ADDRESS
 		uint32_t account_index;
 		std::string label;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(account_index)
 		KV_SERIALIZE(label)
 		END_KV_SERIALIZE_MAP()
@@ -163,7 +163,7 @@ struct COMMAND_RPC_CREATE_ADDRESS
 		std::string address;
 		uint32_t address_index;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(address)
 		KV_SERIALIZE(address_index)
 		END_KV_SERIALIZE_MAP()
@@ -177,7 +177,7 @@ struct COMMAND_RPC_LABEL_ADDRESS
 		cryptonote::subaddress_index index;
 		std::string label;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(index)
 		KV_SERIALIZE(label)
 		END_KV_SERIALIZE_MAP()
@@ -185,7 +185,7 @@ struct COMMAND_RPC_LABEL_ADDRESS
 
 	struct response
 	{
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		END_KV_SERIALIZE_MAP()
 	};
 };
@@ -196,7 +196,7 @@ struct COMMAND_RPC_GET_ACCOUNTS
 	{
 		std::string tag; // all accounts if empty, otherwise those accounts with this tag
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(tag)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -210,7 +210,7 @@ struct COMMAND_RPC_GET_ACCOUNTS
 		std::string label;
 		std::string tag;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(subaddress_account_info)
 		KV_SERIALIZE(account_index)
 		KV_SERIALIZE(base_address)
 		KV_SERIALIZE(balance)
@@ -226,7 +226,7 @@ struct COMMAND_RPC_GET_ACCOUNTS
 		uint64_t total_unlocked_balance;
 		std::vector<subaddress_account_info> subaddress_accounts;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(total_balance)
 		KV_SERIALIZE(total_unlocked_balance)
 		KV_SERIALIZE(subaddress_accounts)
@@ -239,7 +239,7 @@ struct COMMAND_RPC_CREATE_ACCOUNT
 	struct request
 	{
 		std::string label;
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(label)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -248,7 +248,7 @@ struct COMMAND_RPC_CREATE_ACCOUNT
 	{
 		uint32_t account_index;
 		std::string address; // the 0-th address for convenience
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(account_index)
 		KV_SERIALIZE(address)
 		END_KV_SERIALIZE_MAP()
@@ -262,7 +262,7 @@ struct COMMAND_RPC_LABEL_ACCOUNT
 		uint32_t account_index;
 		std::string label;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(account_index)
 		KV_SERIALIZE(label)
 		END_KV_SERIALIZE_MAP()
@@ -270,7 +270,7 @@ struct COMMAND_RPC_LABEL_ACCOUNT
 
 	struct response
 	{
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		END_KV_SERIALIZE_MAP()
 	};
 };
@@ -279,7 +279,7 @@ struct COMMAND_RPC_GET_ACCOUNT_TAGS
 {
 	struct request
 	{
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		END_KV_SERIALIZE_MAP()
 	};
 
@@ -289,7 +289,7 @@ struct COMMAND_RPC_GET_ACCOUNT_TAGS
 		std::string label;
 		std::vector<uint32_t> accounts;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(account_tag_info)
 		KV_SERIALIZE(tag);
 		KV_SERIALIZE(label);
 		KV_SERIALIZE(accounts);
@@ -300,7 +300,7 @@ struct COMMAND_RPC_GET_ACCOUNT_TAGS
 	{
 		std::vector<account_tag_info> account_tags;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(account_tags)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -313,7 +313,7 @@ struct COMMAND_RPC_TAG_ACCOUNTS
 		std::string tag;
 		std::set<uint32_t> accounts;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(tag)
 		KV_SERIALIZE(accounts)
 		END_KV_SERIALIZE_MAP()
@@ -321,7 +321,7 @@ struct COMMAND_RPC_TAG_ACCOUNTS
 
 	struct response
 	{
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		END_KV_SERIALIZE_MAP()
 	};
 };
@@ -332,14 +332,14 @@ struct COMMAND_RPC_UNTAG_ACCOUNTS
 	{
 		std::set<uint32_t> accounts;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(accounts)
 		END_KV_SERIALIZE_MAP()
 	};
 
 	struct response
 	{
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		END_KV_SERIALIZE_MAP()
 	};
 };
@@ -351,7 +351,7 @@ struct COMMAND_RPC_SET_ACCOUNT_TAG_DESCRIPTION
 		std::string tag;
 		std::string description;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(tag)
 		KV_SERIALIZE(description)
 		END_KV_SERIALIZE_MAP()
@@ -359,7 +359,7 @@ struct COMMAND_RPC_SET_ACCOUNT_TAG_DESCRIPTION
 
 	struct response
 	{
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		END_KV_SERIALIZE_MAP()
 	};
 };
@@ -368,14 +368,14 @@ struct COMMAND_RPC_GET_HEIGHT
 {
 	struct request
 	{
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		END_KV_SERIALIZE_MAP()
 	};
 
 	struct response
 	{
 		uint64_t height;
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(height)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -385,7 +385,7 @@ struct transfer_destination
 {
 	uint64_t amount;
 	std::string address;
-	BEGIN_KV_SERIALIZE_MAP()
+	BEGIN_KV_SERIALIZE_MAP(transfer_destination)
 	KV_SERIALIZE(amount)
 	KV_SERIALIZE(address)
 	END_KV_SERIALIZE_MAP()
@@ -408,7 +408,7 @@ struct COMMAND_RPC_TRANSFER
 		bool get_tx_hex;
 		bool get_tx_metadata;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(destinations)
 		KV_SERIALIZE(account_index)
 		KV_SERIALIZE(subaddr_indices)
@@ -435,7 +435,7 @@ struct COMMAND_RPC_TRANSFER
 		std::string tx_metadata;
 		std::string multisig_txset;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(tx_hash)
 		KV_SERIALIZE(tx_key)
 		KV_SERIALIZE(amount_keys)
@@ -465,7 +465,7 @@ struct COMMAND_RPC_TRANSFER_SPLIT
 		bool get_tx_hex;
 		bool get_tx_metadata;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(destinations)
 		KV_SERIALIZE(account_index)
 		KV_SERIALIZE(subaddr_indices)
@@ -485,7 +485,7 @@ struct COMMAND_RPC_TRANSFER_SPLIT
 	{
 		std::list<std::string> keys;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(key_list)
 		KV_SERIALIZE(keys)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -500,7 +500,7 @@ struct COMMAND_RPC_TRANSFER_SPLIT
 		std::list<std::string> tx_metadata_list;
 		std::string multisig_txset;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(tx_hash_list)
 		KV_SERIALIZE(tx_key_list)
 		KV_SERIALIZE(amount_list)
@@ -530,7 +530,7 @@ struct COMMAND_RPC_SWEEP_ALL
 		bool get_tx_hex;
 		bool get_tx_metadata;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(address)
 		KV_SERIALIZE(account_index)
 		KV_SERIALIZE(subaddr_indices)
@@ -551,7 +551,7 @@ struct COMMAND_RPC_SWEEP_ALL
 	{
 		std::list<std::string> keys;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(key_list)
 		KV_SERIALIZE(keys)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -566,7 +566,7 @@ struct COMMAND_RPC_SWEEP_ALL
 		std::list<std::string> tx_metadata_list;
 		std::string multisig_txset;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(tx_hash_list)
 		KV_SERIALIZE(tx_key_list)
 		KV_SERIALIZE(amount_list)
@@ -594,7 +594,7 @@ struct COMMAND_RPC_SWEEP_SINGLE
 		bool get_tx_hex;
 		bool get_tx_metadata;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(address)
 		KV_SERIALIZE(priority)
 		KV_SERIALIZE_OPT(mixin, (uint64_t)0)
@@ -619,7 +619,7 @@ struct COMMAND_RPC_SWEEP_SINGLE
 		std::string tx_metadata;
 		std::string multisig_txset;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(tx_hash)
 		KV_SERIALIZE(tx_key)
 		KV_SERIALIZE(amount)
@@ -637,7 +637,7 @@ struct COMMAND_RPC_RELAY_TX
 	{
 		std::string hex;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(hex)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -649,7 +649,7 @@ struct COMMAND_RPC_RELAY_TX
 		uint64_t fee;
 		std::string tx_blob;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(tx_hash)
 		KV_SERIALIZE(tx_key)
 		KV_SERIALIZE(fee)
@@ -662,13 +662,13 @@ struct COMMAND_RPC_STORE
 {
 	struct request
 	{
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		END_KV_SERIALIZE_MAP()
 	};
 
 	struct response
 	{
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		END_KV_SERIALIZE_MAP()
 	};
 };
@@ -683,7 +683,7 @@ struct payment_details
 	cryptonote::subaddress_index subaddr_index;
 	std::string address;
 
-	BEGIN_KV_SERIALIZE_MAP()
+	BEGIN_KV_SERIALIZE_MAP(payment_details)
 	KV_SERIALIZE(payment_id)
 	KV_SERIALIZE(tx_hash)
 	KV_SERIALIZE(amount)
@@ -700,7 +700,7 @@ struct COMMAND_RPC_GET_PAYMENTS
 	{
 		std::string payment_id;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(payment_id)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -709,7 +709,7 @@ struct COMMAND_RPC_GET_PAYMENTS
 	{
 		std::list<payment_details> payments;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(payments)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -722,7 +722,7 @@ struct COMMAND_RPC_GET_BULK_PAYMENTS
 		std::vector<std::string> payment_ids;
 		uint64_t min_block_height;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(payment_ids)
 		KV_SERIALIZE(min_block_height)
 		END_KV_SERIALIZE_MAP()
@@ -732,7 +732,7 @@ struct COMMAND_RPC_GET_BULK_PAYMENTS
 	{
 		std::list<payment_details> payments;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(payments)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -748,7 +748,7 @@ struct transfer_details
 	uint32_t subaddr_index;
 	std::string key_image;
 
-	BEGIN_KV_SERIALIZE_MAP()
+	BEGIN_KV_SERIALIZE_MAP(transfer_details)
 	KV_SERIALIZE(amount)
 	KV_SERIALIZE(spent)
 	KV_SERIALIZE(global_index)
@@ -768,7 +768,7 @@ struct COMMAND_RPC_INCOMING_TRANSFERS
 		std::set<uint32_t> subaddr_indices;
 		bool verbose;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(transfer_type)
 		KV_SERIALIZE(account_index)
 		KV_SERIALIZE(subaddr_indices)
@@ -780,7 +780,7 @@ struct COMMAND_RPC_INCOMING_TRANSFERS
 	{
 		std::list<transfer_details> transfers;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(transfers)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -793,7 +793,7 @@ struct COMMAND_RPC_QUERY_KEY
 	{
 		std::string key_type;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(key_type)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -802,7 +802,7 @@ struct COMMAND_RPC_QUERY_KEY
 	{
 		std::string key;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(key)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -814,7 +814,7 @@ struct COMMAND_RPC_MAKE_INTEGRATED_ADDRESS
 	{
 		std::string payment_id;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(payment_id)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -824,7 +824,7 @@ struct COMMAND_RPC_MAKE_INTEGRATED_ADDRESS
 		std::string integrated_address;
 		std::string payment_id;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(integrated_address)
 		KV_SERIALIZE(payment_id)
 		END_KV_SERIALIZE_MAP()
@@ -837,7 +837,7 @@ struct COMMAND_RPC_SPLIT_INTEGRATED_ADDRESS
 	{
 		std::string integrated_address;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(integrated_address)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -848,7 +848,7 @@ struct COMMAND_RPC_SPLIT_INTEGRATED_ADDRESS
 		std::string payment_id;
 		bool is_subaddress;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(standard_address)
 		KV_SERIALIZE(payment_id)
 		KV_SERIALIZE(is_subaddress)
@@ -860,13 +860,13 @@ struct COMMAND_RPC_STOP_WALLET
 {
 	struct request
 	{
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		END_KV_SERIALIZE_MAP()
 	};
 
 	struct response
 	{
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		END_KV_SERIALIZE_MAP()
 	};
 };
@@ -876,14 +876,14 @@ struct COMMAND_RPC_RESCAN_BLOCKCHAIN
 	struct request
 	{
 		bool full_rescan;
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE_OPT(full_rescan, false)
 		END_KV_SERIALIZE_MAP()
 	};
 
 	struct response
 	{
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		END_KV_SERIALIZE_MAP()
 	};
 };
@@ -895,7 +895,7 @@ struct COMMAND_RPC_SET_TX_NOTES
 		std::list<std::string> txids;
 		std::list<std::string> notes;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(txids)
 		KV_SERIALIZE(notes)
 		END_KV_SERIALIZE_MAP()
@@ -903,7 +903,7 @@ struct COMMAND_RPC_SET_TX_NOTES
 
 	struct response
 	{
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		END_KV_SERIALIZE_MAP()
 	};
 };
@@ -914,7 +914,7 @@ struct COMMAND_RPC_GET_TX_NOTES
 	{
 		std::list<std::string> txids;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(txids)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -923,7 +923,7 @@ struct COMMAND_RPC_GET_TX_NOTES
 	{
 		std::list<std::string> notes;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(notes)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -936,7 +936,7 @@ struct COMMAND_RPC_SET_ATTRIBUTE
 		std::string key;
 		std::string value;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(key)
 		KV_SERIALIZE(value)
 		END_KV_SERIALIZE_MAP()
@@ -944,7 +944,7 @@ struct COMMAND_RPC_SET_ATTRIBUTE
 
 	struct response
 	{
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		END_KV_SERIALIZE_MAP()
 	};
 };
@@ -956,7 +956,7 @@ struct COMMAND_RPC_GET_ATTRIBUTE
 
 		std::string key;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(key)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -965,7 +965,7 @@ struct COMMAND_RPC_GET_ATTRIBUTE
 	{
 		std::string value;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(value)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -977,7 +977,7 @@ struct COMMAND_RPC_GET_TX_KEY
 	{
 		std::string txid;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(txid)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -986,7 +986,7 @@ struct COMMAND_RPC_GET_TX_KEY
 	{
 		std::string tx_key;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(tx_key)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -1000,7 +1000,7 @@ struct COMMAND_RPC_CHECK_TX_KEY
 		std::string tx_key;
 		std::string address;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(txid)
 		KV_SERIALIZE(tx_key)
 		KV_SERIALIZE(address)
@@ -1013,7 +1013,7 @@ struct COMMAND_RPC_CHECK_TX_KEY
 		bool in_pool;
 		uint64_t confirmations;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(received)
 		KV_SERIALIZE(in_pool)
 		KV_SERIALIZE(confirmations)
@@ -1029,7 +1029,7 @@ struct COMMAND_RPC_GET_TX_PROOF
 		std::string address;
 		std::string message;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(txid)
 		KV_SERIALIZE(address)
 		KV_SERIALIZE(message)
@@ -1040,7 +1040,7 @@ struct COMMAND_RPC_GET_TX_PROOF
 	{
 		std::string signature;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(signature)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -1055,7 +1055,7 @@ struct COMMAND_RPC_CHECK_TX_PROOF
 		std::string message;
 		std::string signature;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(txid)
 		KV_SERIALIZE(address)
 		KV_SERIALIZE(message)
@@ -1070,7 +1070,7 @@ struct COMMAND_RPC_CHECK_TX_PROOF
 		bool in_pool;
 		uint64_t confirmations;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(good)
 		KV_SERIALIZE(received)
 		KV_SERIALIZE(in_pool)
@@ -1095,7 +1095,7 @@ struct transfer_entry
 	std::string address;
 	bool double_spend_seen;
 
-	BEGIN_KV_SERIALIZE_MAP()
+	BEGIN_KV_SERIALIZE_MAP(transfer_entry)
 	KV_SERIALIZE(txid);
 	KV_SERIALIZE(payment_id);
 	KV_SERIALIZE(height);
@@ -1119,7 +1119,7 @@ struct COMMAND_RPC_GET_SPEND_PROOF
 		std::string txid;
 		std::string message;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(txid)
 		KV_SERIALIZE(message)
 		END_KV_SERIALIZE_MAP()
@@ -1129,7 +1129,7 @@ struct COMMAND_RPC_GET_SPEND_PROOF
 	{
 		std::string signature;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(signature)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -1143,7 +1143,7 @@ struct COMMAND_RPC_CHECK_SPEND_PROOF
 		std::string message;
 		std::string signature;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(txid)
 		KV_SERIALIZE(message)
 		KV_SERIALIZE(signature)
@@ -1154,7 +1154,7 @@ struct COMMAND_RPC_CHECK_SPEND_PROOF
 	{
 		bool good;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(good)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -1169,7 +1169,7 @@ struct COMMAND_RPC_GET_RESERVE_PROOF
 		uint64_t amount;		// ignored when `all` is true
 		std::string message;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(all)
 		KV_SERIALIZE(account_index)
 		KV_SERIALIZE(amount)
@@ -1181,7 +1181,7 @@ struct COMMAND_RPC_GET_RESERVE_PROOF
 	{
 		std::string signature;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(signature)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -1195,7 +1195,7 @@ struct COMMAND_RPC_CHECK_RESERVE_PROOF
 		std::string message;
 		std::string signature;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(address)
 		KV_SERIALIZE(message)
 		KV_SERIALIZE(signature)
@@ -1208,7 +1208,7 @@ struct COMMAND_RPC_CHECK_RESERVE_PROOF
 		uint64_t total;
 		uint64_t spent;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(good)
 		KV_SERIALIZE(total)
 		KV_SERIALIZE(spent)
@@ -1232,7 +1232,7 @@ struct COMMAND_RPC_GET_TRANSFERS
 		uint32_t account_index;
 		std::set<uint32_t> subaddr_indices;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(in);
 		KV_SERIALIZE(out);
 		KV_SERIALIZE(pending);
@@ -1254,7 +1254,7 @@ struct COMMAND_RPC_GET_TRANSFERS
 		std::list<transfer_entry> failed;
 		std::list<transfer_entry> pool;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(in);
 		KV_SERIALIZE(out);
 		KV_SERIALIZE(pending);
@@ -1271,7 +1271,7 @@ struct COMMAND_RPC_GET_TRANSFER_BY_TXID
 		std::string txid;
 		uint32_t account_index;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(txid);
 		KV_SERIALIZE_OPT(account_index, (uint32_t)0)
 		END_KV_SERIALIZE_MAP()
@@ -1281,7 +1281,7 @@ struct COMMAND_RPC_GET_TRANSFER_BY_TXID
 	{
 		transfer_entry transfer;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(transfer);
 		END_KV_SERIALIZE_MAP()
 	};
@@ -1293,7 +1293,7 @@ struct COMMAND_RPC_SIGN
 	{
 		std::string data;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(data);
 		END_KV_SERIALIZE_MAP()
 	};
@@ -1302,7 +1302,7 @@ struct COMMAND_RPC_SIGN
 	{
 		std::string signature;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(signature);
 		END_KV_SERIALIZE_MAP()
 	};
@@ -1316,7 +1316,7 @@ struct COMMAND_RPC_VERIFY
 		std::string address;
 		std::string signature;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(data);
 		KV_SERIALIZE(address);
 		KV_SERIALIZE(signature);
@@ -1327,7 +1327,7 @@ struct COMMAND_RPC_VERIFY
 	{
 		bool good;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(good);
 		END_KV_SERIALIZE_MAP()
 	};
@@ -1339,14 +1339,14 @@ struct COMMAND_RPC_EXPORT_KEY_IMAGES
 	{
 		std::string filename;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(filename);
 		END_KV_SERIALIZE_MAP()
 	};
 
 	struct response
 	{
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		END_KV_SERIALIZE_MAP()
 	};
 };
@@ -1357,7 +1357,7 @@ struct COMMAND_RPC_IMPORT_KEY_IMAGES
 	{
 		std::string filename;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(filename);
 		END_KV_SERIALIZE_MAP()
 	};
@@ -1368,7 +1368,7 @@ struct COMMAND_RPC_IMPORT_KEY_IMAGES
 		uint64_t spent;
 		uint64_t unspent;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(height)
 		KV_SERIALIZE(spent)
 		KV_SERIALIZE(unspent)
@@ -1384,7 +1384,7 @@ struct uri_spec
 	std::string tx_description;
 	std::string recipient_name;
 
-	BEGIN_KV_SERIALIZE_MAP()
+	BEGIN_KV_SERIALIZE_MAP(uri_spec)
 	KV_SERIALIZE(address);
 	KV_SERIALIZE(payment_id);
 	KV_SERIALIZE(amount);
@@ -1403,7 +1403,7 @@ struct COMMAND_RPC_MAKE_URI
 	{
 		std::string uri;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(uri)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -1415,7 +1415,7 @@ struct COMMAND_RPC_PARSE_URI
 	{
 		std::string uri;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(uri)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -1425,7 +1425,7 @@ struct COMMAND_RPC_PARSE_URI
 		uri_spec uri;
 		std::vector<std::string> unknown_parameters;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(uri);
 		KV_SERIALIZE(unknown_parameters);
 		END_KV_SERIALIZE_MAP()
@@ -1440,7 +1440,7 @@ struct COMMAND_RPC_ADD_ADDRESS_BOOK_ENTRY
 		std::string payment_id;
 		std::string description;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(address)
 		KV_SERIALIZE(payment_id)
 		KV_SERIALIZE(description)
@@ -1451,7 +1451,7 @@ struct COMMAND_RPC_ADD_ADDRESS_BOOK_ENTRY
 	{
 		uint64_t index;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(index);
 		END_KV_SERIALIZE_MAP()
 	};
@@ -1463,19 +1463,21 @@ struct COMMAND_RPC_GET_ADDRESS_BOOK_ENTRY
 	{
 		std::list<uint64_t> entries;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(entries)
 		END_KV_SERIALIZE_MAP()
 	};
 
 	struct entry
 	{
+		entry(uint64_t index, std::string address, std::string payment_id, std::string description) : index(index), address(address), payment_id(payment_id), description(description)  {}
+
 		uint64_t index;
 		std::string address;
 		std::string payment_id;
 		std::string description;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(entry)
 		KV_SERIALIZE(index)
 		KV_SERIALIZE(address)
 		KV_SERIALIZE(payment_id)
@@ -1487,7 +1489,7 @@ struct COMMAND_RPC_GET_ADDRESS_BOOK_ENTRY
 	{
 		std::vector<entry> entries;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(entries)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -1499,14 +1501,14 @@ struct COMMAND_RPC_DELETE_ADDRESS_BOOK_ENTRY
 	{
 		uint64_t index;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(index);
 		END_KV_SERIALIZE_MAP()
 	};
 
 	struct response
 	{
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		END_KV_SERIALIZE_MAP()
 	};
 };
@@ -1515,13 +1517,13 @@ struct COMMAND_RPC_RESCAN_SPENT
 {
 	struct request
 	{
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		END_KV_SERIALIZE_MAP()
 	};
 
 	struct response
 	{
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		END_KV_SERIALIZE_MAP()
 	};
 };
@@ -1534,7 +1536,7 @@ struct COMMAND_RPC_START_MINING
 		bool do_background_mining;
 		bool ignore_battery;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(threads_count)
 		KV_SERIALIZE(do_background_mining)
 		KV_SERIALIZE(ignore_battery)
@@ -1543,7 +1545,7 @@ struct COMMAND_RPC_START_MINING
 
 	struct response
 	{
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		END_KV_SERIALIZE_MAP()
 	};
 };
@@ -1552,13 +1554,13 @@ struct COMMAND_RPC_STOP_MINING
 {
 	struct request
 	{
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		END_KV_SERIALIZE_MAP()
 	};
 
 	struct response
 	{
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		END_KV_SERIALIZE_MAP()
 	};
 };
@@ -1567,14 +1569,14 @@ struct COMMAND_RPC_GET_LANGUAGES
 {
 	struct request
 	{
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		END_KV_SERIALIZE_MAP()
 	};
 	struct response
 	{
 		std::vector<std::string> languages;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(languages)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -1589,7 +1591,7 @@ struct COMMAND_RPC_CREATE_WALLET
 		std::string language;
 		bool short_address;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(filename)
 		KV_SERIALIZE(password)
 		KV_SERIALIZE(language)
@@ -1598,7 +1600,7 @@ struct COMMAND_RPC_CREATE_WALLET
 	};
 	struct response
 	{
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		END_KV_SERIALIZE_MAP()
 	};
 };
@@ -1612,7 +1614,7 @@ struct COMMAND_RPC_RESTORE_WALLET
 		std::string seed;
 		uint64_t refresh_start_height;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(filename)
 		KV_SERIALIZE(password)
 		KV_SERIALIZE(seed)
@@ -1621,7 +1623,7 @@ struct COMMAND_RPC_RESTORE_WALLET
 	};
 	struct response
 	{
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		END_KV_SERIALIZE_MAP()
 	};
 };
@@ -1636,7 +1638,7 @@ struct COMMAND_RPC_RESTORE_VIEW_WALLET
 		std::string viewkey;
 		uint64_t refresh_start_height;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(filename)
 		KV_SERIALIZE(password)
 		KV_SERIALIZE(address)
@@ -1646,7 +1648,7 @@ struct COMMAND_RPC_RESTORE_VIEW_WALLET
 	};
 	struct response
 	{
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		END_KV_SERIALIZE_MAP()
 	};
 };
@@ -1658,14 +1660,14 @@ struct COMMAND_RPC_OPEN_WALLET
 		std::string filename;
 		std::string password;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(filename)
 		KV_SERIALIZE(password)
 		END_KV_SERIALIZE_MAP()
 	};
 	struct response
 	{
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		END_KV_SERIALIZE_MAP()
 	};
 };
@@ -1677,14 +1679,14 @@ struct COMMAND_RPC_CHANGE_WALLET_PASSWORD
 		std::string old_password;
 		std::string new_password;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(old_password)
 		KV_SERIALIZE(new_password)
 		END_KV_SERIALIZE_MAP()
 	};
 	struct response
 	{
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		END_KV_SERIALIZE_MAP()
 	};
 };
@@ -1693,12 +1695,12 @@ struct COMMAND_RPC_CLOSE_WALLET
 {
 	struct request
 	{
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		END_KV_SERIALIZE_MAP()
 	};
 	struct response
 	{
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		END_KV_SERIALIZE_MAP()
 	};
 };
@@ -1707,7 +1709,7 @@ struct COMMAND_RPC_IS_MULTISIG
 {
 	struct request
 	{
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		END_KV_SERIALIZE_MAP()
 	};
 
@@ -1718,7 +1720,7 @@ struct COMMAND_RPC_IS_MULTISIG
 		uint32_t threshold;
 		uint32_t total;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(multisig)
 		KV_SERIALIZE(ready)
 		KV_SERIALIZE(threshold)
@@ -1731,7 +1733,7 @@ struct COMMAND_RPC_PREPARE_MULTISIG
 {
 	struct request
 	{
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		END_KV_SERIALIZE_MAP()
 	};
 
@@ -1739,7 +1741,7 @@ struct COMMAND_RPC_PREPARE_MULTISIG
 	{
 		std::string multisig_info;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(multisig_info)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -1753,7 +1755,7 @@ struct COMMAND_RPC_MAKE_MULTISIG
 		uint32_t threshold;
 		std::string password;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(multisig_info)
 		KV_SERIALIZE(threshold)
 		KV_SERIALIZE(password)
@@ -1765,7 +1767,7 @@ struct COMMAND_RPC_MAKE_MULTISIG
 		std::string address;
 		std::string multisig_info;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(address)
 		KV_SERIALIZE(multisig_info)
 		END_KV_SERIALIZE_MAP()
@@ -1776,7 +1778,7 @@ struct COMMAND_RPC_EXPORT_MULTISIG
 {
 	struct request
 	{
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		END_KV_SERIALIZE_MAP()
 	};
 
@@ -1784,7 +1786,7 @@ struct COMMAND_RPC_EXPORT_MULTISIG
 	{
 		std::string info;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(info)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -1796,7 +1798,7 @@ struct COMMAND_RPC_IMPORT_MULTISIG
 	{
 		std::vector<std::string> info;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(info)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -1805,7 +1807,7 @@ struct COMMAND_RPC_IMPORT_MULTISIG
 	{
 		uint64_t n_outputs;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(n_outputs)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -1818,7 +1820,7 @@ struct COMMAND_RPC_FINALIZE_MULTISIG
 		std::string password;
 		std::vector<std::string> multisig_info;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(password)
 		KV_SERIALIZE(multisig_info)
 		END_KV_SERIALIZE_MAP()
@@ -1828,7 +1830,7 @@ struct COMMAND_RPC_FINALIZE_MULTISIG
 	{
 		std::string address;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(address)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -1840,7 +1842,7 @@ struct COMMAND_RPC_SIGN_MULTISIG
 	{
 		std::string tx_data_hex;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(tx_data_hex)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -1850,7 +1852,7 @@ struct COMMAND_RPC_SIGN_MULTISIG
 		std::string tx_data_hex;
 		std::list<std::string> tx_hash_list;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(tx_data_hex)
 		KV_SERIALIZE(tx_hash_list)
 		END_KV_SERIALIZE_MAP()
@@ -1863,7 +1865,7 @@ struct COMMAND_RPC_SUBMIT_MULTISIG
 	{
 		std::string tx_data_hex;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(tx_data_hex)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -1872,7 +1874,7 @@ struct COMMAND_RPC_SUBMIT_MULTISIG
 	{
 		std::list<std::string> tx_hash_list;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(tx_hash_list)
 		END_KV_SERIALIZE_MAP()
 	};

--- a/tests/net_load_tests/net_load_tests.h
+++ b/tests/net_load_tests/net_load_tests.h
@@ -227,7 +227,7 @@ struct CMD_CLOSE_ALL_CONNECTIONS
 
 	struct request
 	{
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		END_KV_SERIALIZE_MAP()
 	};
 };
@@ -241,7 +241,7 @@ struct CMD_START_OPEN_CLOSE_TEST
 		uint64_t open_request_target;
 		uint64_t max_opened_conn_count;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(open_request_target)
 		KV_SERIALIZE(max_opened_conn_count)
 		END_KV_SERIALIZE_MAP()
@@ -249,7 +249,7 @@ struct CMD_START_OPEN_CLOSE_TEST
 
 	struct response
 	{
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		END_KV_SERIALIZE_MAP()
 	};
 };
@@ -260,7 +260,7 @@ struct CMD_GET_STATISTICS
 
 	struct request
 	{
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		END_KV_SERIALIZE_MAP()
 	};
 
@@ -270,7 +270,7 @@ struct CMD_GET_STATISTICS
 		uint64_t new_connection_counter;
 		uint64_t close_connection_counter;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(opened_connections_count)
 		KV_SERIALIZE(new_connection_counter)
 		KV_SERIALIZE(close_connection_counter)
@@ -291,13 +291,13 @@ struct CMD_RESET_STATISTICS
 
 	struct request
 	{
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		END_KV_SERIALIZE_MAP()
 	};
 
 	struct response
 	{
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		END_KV_SERIALIZE_MAP()
 	};
 };
@@ -308,7 +308,7 @@ struct CMD_SHUTDOWN
 
 	struct request
 	{
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		END_KV_SERIALIZE_MAP()
 	};
 };
@@ -321,7 +321,7 @@ struct CMD_SEND_DATA_REQUESTS
 	{
 		uint64_t request_size;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(request_size)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -336,7 +336,7 @@ struct CMD_DATA_REQUEST
 		std::string data;
 		uint64_t response_size;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(request)
 		KV_SERIALIZE(data)
 		END_KV_SERIALIZE_MAP()
 	};
@@ -345,7 +345,7 @@ struct CMD_DATA_REQUEST
 	{
 		std::string data;
 
-		BEGIN_KV_SERIALIZE_MAP()
+		BEGIN_KV_SERIALIZE_MAP(response)
 		KV_SERIALIZE(data)
 		END_KV_SERIALIZE_MAP()
 	};


### PR DESCRIPTION
Not initialized memory can be send out over the rpc server.
This can be used to readout parts of the main memory.

- default initialize response data

Co-authored-by: fireice-uk <fireice-uk@users.noreply.github.com>

- [x] runtime test with https://github.com/guidovranken/monero-bleed-poc