### PR TITLE
Multi-threaded wallet scan

### DIFF
--- a/src/blockchain_db/blockchain_db.h
+++ b/src/blockchain_db/blockchain_db.h
@@ -1118,6 +1118,7 @@ class BlockchainDB
    * @return true iff the transaction was found
    */
 	virtual bool get_tx_blob(const crypto::hash &h, cryptonote::blobdata &tx) const = 0;
+	virtual bool get_tx_blob_indexed(const crypto::hash& h, cryptonote::blobdata& bd, std::vector<uint64_t>& o_idx) const = 0;
 
 	/**
    * @brief fetches the total number of transactions ever

--- a/src/blockchain_db/lmdb/db_lmdb.h
+++ b/src/blockchain_db/lmdb/db_lmdb.h
@@ -235,6 +235,7 @@ class BlockchainLMDB : public BlockchainDB
 	virtual uint64_t get_tx_unlock_time(const crypto::hash &h) const;
 
 	virtual bool get_tx_blob(const crypto::hash &h, cryptonote::blobdata &tx) const;
+	virtual bool get_tx_blob_indexed(const crypto::hash& h, cryptonote::blobdata& bd, std::vector<uint64_t>& o_idx) const;
 
 	virtual uint64_t get_tx_count() const;
 

--- a/src/common/gulps.hpp
+++ b/src/common/gulps.hpp
@@ -514,9 +514,10 @@ public:
 
 		void output_main()
 		{
-			while(msg_q.wait_for_pop())
+			std::unique_lock<std::mutex> lck;
+			while(msg_q.wait_for_pop(lck))
 			{
-				message msg = msg_q.pop();
+				message msg = msg_q.pop(lck);
 				write_output(msg);
 			}
 		}

--- a/src/cryptonote_basic/cryptonote_format_utils.h
+++ b/src/cryptonote_basic/cryptonote_format_utils.h
@@ -212,6 +212,7 @@ void get_hash_stats(uint64_t &tx_hashes_calculated, uint64_t &tx_hashes_cached, 
 //------------------------------------------------------------------------------------------------------------------------------
 inline blobdata get_pruned_tx_blob(transaction &tx)
 {
+	GULPS_CAT_MAJOR("formt_utils");
 	std::stringstream ss;
 	binary_archive<true> ba(ss);
 	bool r = tx.serialize_base(ba);
@@ -221,6 +222,7 @@ inline blobdata get_pruned_tx_blob(transaction &tx)
 //------------------------------------------------------------------------------------------------------------------------------
 inline blobdata get_pruned_tx_blob(const blobdata &blobdata)
 {
+	GULPS_CAT_MAJOR("formt_utils");
 	cryptonote::transaction tx;
 
 	if(!cryptonote::parse_and_validate_tx_base_from_blob(blobdata, tx))

--- a/src/cryptonote_basic/cryptonote_format_utils.h
+++ b/src/cryptonote_basic/cryptonote_format_utils.h
@@ -209,6 +209,28 @@ crypto::hash get_tx_tree_hash(const block &b);
 bool is_valid_decomposed_amount(uint64_t amount);
 void get_hash_stats(uint64_t &tx_hashes_calculated, uint64_t &tx_hashes_cached, uint64_t &block_hashes_calculated, uint64_t &block_hashes_cached);
 
+//------------------------------------------------------------------------------------------------------------------------------
+inline blobdata get_pruned_tx_blob(transaction &tx)
+{
+	std::stringstream ss;
+	binary_archive<true> ba(ss);
+	bool r = tx.serialize_base(ba);
+	GULPS_CHECK_AND_ASSERT_MES(r, cryptonote::blobdata(), "Failed to serialize rct signatures base");
+	return ss.str();
+}
+//------------------------------------------------------------------------------------------------------------------------------
+inline blobdata get_pruned_tx_blob(const blobdata &blobdata)
+{
+	cryptonote::transaction tx;
+
+	if(!cryptonote::parse_and_validate_tx_base_from_blob(blobdata, tx))
+	{
+		GULPS_ERROR("Failed to parse and validate tx from blob");
+		return cryptonote::blobdata();
+	}
+	return get_pruned_tx_blob(tx);
+}
+
 #define CHECKED_GET_SPECIFIC_VARIANT(variant_var, specific_type, variable_name, fail_return_val)                                                                                              \
 	GULPS_CHECK_AND_ASSERT_MES(variant_var.type() == typeid(specific_type), fail_return_val, "wrong variant type: " , variant_var.type().name() , ", expected " , typeid(specific_type).name()); \
 	specific_type &variable_name = boost::get<specific_type>(variant_var);

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -437,6 +437,9 @@ class Blockchain
      */
 	bool find_blockchain_supplement(const uint64_t req_start_block, const std::list<crypto::hash> &qblock_ids, std::list<std::pair<cryptonote::blobdata, std::list<cryptonote::blobdata>>> &blocks, uint64_t &total_height, uint64_t &start_height, size_t max_count) const;
 
+	bool find_blockchain_supplement_indexed(const uint64_t req_start_block, const std::list<crypto::hash> &qblock_ids, std::vector<block_complete_entry_v>& blocks,
+			std::vector<COMMAND_RPC_GET_BLOCKS_FAST::block_output_indices>& out_idx, uint64_t &total_height, uint64_t &start_height, size_t max_count) const;
+
 	/**
      * @brief retrieves a set of blocks and their transactions, and possibly other transactions
      *

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -534,6 +534,11 @@ class core : public i_miner_handler
       */
 	bool find_blockchain_supplement(const uint64_t req_start_block, const std::list<crypto::hash> &qblock_ids, std::list<std::pair<cryptonote::blobdata, std::list<cryptonote::blobdata>>> &blocks, uint64_t &total_height, uint64_t &start_height, size_t max_count) const;
 
+	inline bool find_blockchain_supplement_indexed(const uint64_t req_start_block, const std::list<crypto::hash> &qblock_ids, std::vector<block_complete_entry_v>& blocks,
+			std::vector<COMMAND_RPC_GET_BLOCKS_FAST::block_output_indices>& out_idx, uint64_t &total_height, uint64_t &start_height, size_t max_count) const
+	{
+		return m_blockchain_storage.find_blockchain_supplement_indexed(req_start_block, qblock_ids, blocks, out_idx, total_height, start_height, max_count);
+	}
 	/**
       * @brief gets some stats about the daemon
       *

--- a/src/cryptonote_protocol/cryptonote_protocol_defs.h
+++ b/src/cryptonote_protocol/cryptonote_protocol_defs.h
@@ -133,6 +133,19 @@ struct block_complete_entry
 	END_KV_SERIALIZE_MAP()
 };
 
+// As far as epee is concerned, those two are interchangeable
+struct block_complete_entry_v
+{
+	block_complete_entry_v(blobdata block, std::vector<blobdata> txs) : block(block), txs(txs)  {}
+
+	blobdata block;
+	std::vector<blobdata> txs;
+	BEGIN_KV_SERIALIZE_MAP(block_complete_entry_v)
+	KV_SERIALIZE(block)
+	KV_SERIALIZE(txs)
+	END_KV_SERIALIZE_MAP()
+};
+
 /************************************************************************/
 /*                                                                      */
 /************************************************************************/

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -126,7 +126,7 @@ struct COMMAND_RPC_GET_BLOCKS_FAST
 
 	struct response
 	{
-		std::list<block_complete_entry> blocks;
+		std::vector<block_complete_entry_v> blocks;
 		uint64_t start_height;
 		uint64_t current_height;
 		std::string status;

--- a/src/wallet/CMakeLists.txt
+++ b/src/wallet/CMakeLists.txt
@@ -48,6 +48,7 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 
 set(wallet_sources
   wallet2.cpp
+  wallet2_tx_scan.cpp
   wallet_args.cpp
   ringdb.cpp
   node_rpc_proxy.cpp)

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -528,20 +528,6 @@ static void emplace_or_replace(std::unordered_multimap<crypto::hash, tools::wall
 	container.emplace(key, pd);
 }
 
-void drop_from_short_history(std::list<crypto::hash> &short_chain_history, size_t N)
-{
-	std::list<crypto::hash>::iterator right;
-	// drop early N off, skipping the genesis block
-	if(short_chain_history.size() > N)
-	{
-		right = short_chain_history.end();
-		std::advance(right, -1);
-		std::list<crypto::hash>::iterator left = right;
-		std::advance(left, -N);
-		short_chain_history.erase(left, right);
-	}
-}
-
 size_t estimate_rct_tx_size(int n_inputs, int mixin, int n_outputs, size_t extra_size, bool bulletproof)
 {
 	size_t size = 0;
@@ -997,19 +983,8 @@ void wallet2::check_acc_out_precomp(const tx_out &o, const crypto::key_derivatio
 		GULPS_LOG_ERROR("wrong type id in transaction out");
 		return;
 	}
-#ifdef HAVE_EC_64
-	tx_scan_info.received = is_out_to_acc_precomp_64(m_subaddresses, boost::get<txout_to_key>(o.target).key, derivation, additional_derivations, i, hwdev);
-	if(tx_scan_info.received)
-	{
-		//Extra check on the baseline version.
-		tx_scan_info.received = is_out_to_acc_precomp(m_subaddresses, boost::get<txout_to_key>(o.target).key, derivation, additional_derivations, i, hwdev);
-		if(!tx_scan_info.received)
-			GULPS_LOG_ERROR("ERROR! Results of precomp_64 and precomp differ!");
-		assert(tx_scan_info.received);
-	}
-#else
+
 	tx_scan_info.received = is_out_to_acc_precomp(m_subaddresses, boost::get<txout_to_key>(o.target).key, derivation, additional_derivations, i, hwdev);
-#endif
 	if(tx_scan_info.received)
 	{
 		tx_scan_info.money_transfered = o.amount; // may be 0 for ringct outputs
@@ -1138,11 +1113,7 @@ void wallet2::process_new_transaction(const crypto::hash &txid, const cryptonote
 
 		hwdev_lock.lock();
 		hwdev.set_mode(hw::device::TRANSACTION_PARSE);
-#ifdef HAVE_EC_64
-		bool derivation_result = hwdev.generate_key_derivation_64(tx_pub_key, keys.m_view_secret_key, derivation);
-#else
 		bool derivation_result = hwdev.generate_key_derivation(tx_pub_key, keys.m_view_secret_key, derivation);
-#endif
 		if(!derivation_result)
 		{
 			GULPS_WARN("Failed to generate key derivation from tx pubkey, skipping");
@@ -1159,11 +1130,7 @@ void wallet2::process_new_transaction(const crypto::hash &txid, const cryptonote
 		for(size_t i = 0; i < additional_tx_pub_keys.size(); ++i)
 		{
 			additional_derivations.push_back({});
-#ifdef HAVE_EC_64
-			derivation_result = hwdev.generate_key_derivation_64(additional_tx_pub_keys[i], keys.m_view_secret_key, additional_derivations.back());
-#else
 			derivation_result = hwdev.generate_key_derivation(additional_tx_pub_keys[i], keys.m_view_secret_key, additional_derivations.back());
-#endif
 			if(!derivation_result)
 			{
 				GULPS_WARN("Failed to generate key derivation from tx pubkey, skipping");
@@ -1586,48 +1553,6 @@ void wallet2::process_outgoing(const crypto::hash &txid, const cryptonote::trans
 	add_rings(tx);
 }
 //----------------------------------------------------------------------------------------------------
-void wallet2::process_new_blockchain_entry(const cryptonote::block &b, const cryptonote::block_complete_entry &bche, const crypto::hash &bl_id, uint64_t height, const cryptonote::COMMAND_RPC_GET_BLOCKS_FAST::block_output_indices &o_indices)
-{
-	size_t txidx = 0;
-	THROW_WALLET_EXCEPTION_IF(bche.txs.size() + 1 != o_indices.indices.size(), error::wallet_internal_error,
-							  "block transactions=" + std::to_string(bche.txs.size()) +
-								  " not match with daemon response size=" + std::to_string(o_indices.indices.size()));
-
-	//handle transactions from new block
-
-	//optimization if m_explicit_refresh_from_block_height is false: seeking only for blocks that are not older then the wallet creation time plus 1 day. 1 day is for possible user incorrect time setup
-	if(!m_explicit_refresh_from_block_height || (b.timestamp + 60 * 60 * 24 > m_account.get_createtime() && height >= m_refresh_from_block_height))
-	{
-		TIME_MEASURE_START(miner_tx_handle_time);
-		process_new_transaction(get_transaction_hash(b.miner_tx), b.miner_tx, o_indices.indices[txidx++].indices, height, b.timestamp, true, false, false);
-		TIME_MEASURE_FINISH(miner_tx_handle_time);
-
-		TIME_MEASURE_START(txs_handle_time);
-		THROW_WALLET_EXCEPTION_IF(bche.txs.size() != b.tx_hashes.size(), error::wallet_internal_error, "Wrong amount of transactions for block");
-		size_t idx = 0;
-		for(const auto &txblob : bche.txs)
-		{
-			cryptonote::transaction tx;
-			bool r = parse_and_validate_tx_base_from_blob(txblob, tx);
-			THROW_WALLET_EXCEPTION_IF(!r, error::tx_parse_error, txblob);
-			process_new_transaction(b.tx_hashes[idx], tx, o_indices.indices[txidx++].indices, height, b.timestamp, false, false, false);
-			++idx;
-		}
-		TIME_MEASURE_FINISH(txs_handle_time);
-		GULPS_LOG_L2("Processed block: ", bl_id, ", height ", height, ", ", miner_tx_handle_time + txs_handle_time, "(", miner_tx_handle_time, "/", txs_handle_time, ")ms");
-	}
-	else
-	{
-		if(!(height % 100))
-			GULPS_LOG_L2("Skipped block by timestamp, height: ", height, ", block time ", b.timestamp, ", account time ", m_account.get_createtime());
-	}
-	m_blockchain.push_back(bl_id);
-	++m_local_bc_height;
-
-	if(0 != m_callback)
-		m_callback->on_new_block(height, b);
-}
-//----------------------------------------------------------------------------------------------------
 void wallet2::get_short_chain_history(std::list<crypto::hash> &ids) const
 {
 	size_t i = 0;
@@ -1668,56 +1593,6 @@ void wallet2::parse_block_round(const cryptonote::blobdata &blob, cryptonote::bl
 		bl_id = get_block_hash(bl);
 }
 //----------------------------------------------------------------------------------------------------
-void wallet2::pull_blocks(uint64_t start_height, uint64_t &blocks_start_height, const std::list<crypto::hash> &short_chain_history, std::list<cryptonote::block_complete_entry> &blocks, std::vector<cryptonote::COMMAND_RPC_GET_BLOCKS_FAST::block_output_indices> &o_indices)
-{
-	cryptonote::COMMAND_RPC_GET_BLOCKS_FAST::request req = AUTO_VAL_INIT(req);
-	cryptonote::COMMAND_RPC_GET_BLOCKS_FAST::response res = AUTO_VAL_INIT(res);
-	req.block_ids = short_chain_history;
-
-	uint32_t rpc_version;
-	boost::optional<std::string> result = m_node_rpc_proxy.get_rpc_version(rpc_version);
-	// no error
-	if(!!result)
-	{
-		// empty string -> not connection
-		THROW_WALLET_EXCEPTION_IF(result->empty(), tools::error::no_connection_to_daemon, "getversion");
-		THROW_WALLET_EXCEPTION_IF(*result == CORE_RPC_STATUS_BUSY, tools::error::daemon_busy, "getversion");
-		if(*result != CORE_RPC_STATUS_OK)
-		{
-			GULPS_LOG_L1("Cannot determine daemon RPC version, not asking for pruned blocks");
-			req.prune = false; // old daemon
-		}
-	}
-	else
-	{
-		if(rpc_version >= MAKE_CORE_RPC_VERSION(1, 7))
-		{
-			GULPS_LOG_L1("Daemon is recent enough, asking for pruned blocks");
-			req.prune = true;
-		}
-		else
-		{
-			GULPS_LOG_L1("Daemon is too old, not asking for pruned blocks");
-			req.prune = false;
-		}
-	}
-
-	req.start_height = start_height;
-	m_daemon_rpc_mutex.lock();
-	bool r = net_utils::invoke_http_bin("/getblocks.bin", req, res, m_http_client, rpc_timeout);
-	m_daemon_rpc_mutex.unlock();
-	THROW_WALLET_EXCEPTION_IF(!r, error::no_connection_to_daemon, "getblocks.bin");
-	THROW_WALLET_EXCEPTION_IF(res.status == CORE_RPC_STATUS_BUSY, error::daemon_busy, "getblocks.bin");
-	THROW_WALLET_EXCEPTION_IF(res.status != CORE_RPC_STATUS_OK, error::get_blocks_error, res.status);
-	THROW_WALLET_EXCEPTION_IF(res.blocks.size() != res.output_indices.size(), error::wallet_internal_error,
-							  "mismatched blocks (" + boost::lexical_cast<std::string>(res.blocks.size()) + ") and output_indices (" +
-								  boost::lexical_cast<std::string>(res.output_indices.size()) + ") sizes from daemon");
-
-	blocks_start_height = res.start_height;
-	blocks = res.blocks;
-	o_indices = res.output_indices;
-}
-//----------------------------------------------------------------------------------------------------
 void wallet2::pull_hashes(uint64_t start_height, uint64_t &blocks_start_height, const std::list<crypto::hash> &short_chain_history, std::list<crypto::hash> &hashes)
 {
 	cryptonote::COMMAND_RPC_GET_HASHES_FAST::request req = AUTO_VAL_INIT(req);
@@ -1735,109 +1610,7 @@ void wallet2::pull_hashes(uint64_t start_height, uint64_t &blocks_start_height, 
 	blocks_start_height = res.start_height;
 	hashes = res.m_block_ids;
 }
-//----------------------------------------------------------------------------------------------------
-void wallet2::process_blocks(uint64_t start_height, const std::list<cryptonote::block_complete_entry> &blocks, const std::vector<cryptonote::COMMAND_RPC_GET_BLOCKS_FAST::block_output_indices> &o_indices, uint64_t &blocks_added)
-{
-	size_t current_index = start_height;
-	blocks_added = 0;
-	size_t tx_o_indices_idx = 0;
 
-	THROW_WALLET_EXCEPTION_IF(blocks.size() != o_indices.size(), error::wallet_internal_error, "size mismatch");
-	THROW_WALLET_EXCEPTION_IF(!m_blockchain.is_in_bounds(current_index), error::wallet_internal_error, "Index out of bounds of hashchain");
-
-	tools::threadpool &tpool = tools::threadpool::getInstance();
-	int threads = tpool.get_max_concurrency();
-	if(threads > 1)
-	{
-		std::vector<crypto::hash> round_block_hashes(threads);
-		std::vector<cryptonote::block> round_blocks(threads);
-		std::deque<bool> error(threads);
-		size_t blocks_size = blocks.size();
-		std::list<block_complete_entry>::const_iterator blocki = blocks.begin();
-		for(size_t b = 0; b < blocks_size; b += threads)
-		{
-			size_t round_size = std::min((size_t)threads, blocks_size - b);
-			tools::threadpool::waiter waiter;
-
-			std::list<block_complete_entry>::const_iterator tmpblocki = blocki;
-			for(size_t i = 0; i < round_size; ++i)
-			{
-				tpool.submit(&waiter, boost::bind(&wallet2::parse_block_round, this, std::cref(tmpblocki->block),
-												  std::ref(round_blocks[i]), std::ref(round_block_hashes[i]), std::ref(error[i])));
-				++tmpblocki;
-			}
-			waiter.wait();
-			tmpblocki = blocki;
-			for(size_t i = 0; i < round_size; ++i)
-			{
-				THROW_WALLET_EXCEPTION_IF(error[i], error::block_parse_error, tmpblocki->block);
-				++tmpblocki;
-			}
-			for(size_t i = 0; i < round_size; ++i)
-			{
-				const crypto::hash &bl_id = round_block_hashes[i];
-				cryptonote::block &bl = round_blocks[i];
-
-				if(current_index >= m_blockchain.size())
-				{
-					process_new_blockchain_entry(bl, *blocki, bl_id, current_index, o_indices[b + i]);
-					++blocks_added;
-				}
-				else if(bl_id != m_blockchain[current_index])
-				{
-					//split detected here !!!
-					THROW_WALLET_EXCEPTION_IF(current_index == start_height, error::wallet_internal_error,
-											  "wrong daemon response: split starts from the first block in response " + string_tools::pod_to_hex(bl_id) +
-												  " (height " + std::to_string(start_height) + "), local block id at this height: " +
-												  string_tools::pod_to_hex(m_blockchain[current_index]));
-
-					detach_blockchain(current_index);
-					process_new_blockchain_entry(bl, *blocki, bl_id, current_index, o_indices[b + i]);
-				}
-				else
-				{
-					GULPS_LOG_L2("Block is already in blockchain: ", string_tools::pod_to_hex(bl_id));
-				}
-				++current_index;
-				++blocki;
-			}
-		}
-	}
-	else
-	{
-		for(auto &bl_entry : blocks)
-		{
-			cryptonote::block bl;
-			bool r = cryptonote::parse_and_validate_block_from_blob(bl_entry.block, bl);
-			THROW_WALLET_EXCEPTION_IF(!r, error::block_parse_error, bl_entry.block);
-
-			crypto::hash bl_id = get_block_hash(bl);
-			if(current_index >= m_blockchain.size())
-			{
-				process_new_blockchain_entry(bl, bl_entry, bl_id, current_index, o_indices[tx_o_indices_idx]);
-				++blocks_added;
-			}
-			else if(bl_id != m_blockchain[current_index])
-			{
-				//split detected here !!!
-				THROW_WALLET_EXCEPTION_IF(current_index == start_height, error::wallet_internal_error,
-										  "wrong daemon response: split starts from the first block in response " + string_tools::pod_to_hex(bl_id) +
-											  " (height " + std::to_string(start_height) + "), local block id at this height: " +
-											  string_tools::pod_to_hex(m_blockchain[current_index]));
-
-				detach_blockchain(current_index);
-				process_new_blockchain_entry(bl, bl_entry, bl_id, current_index, o_indices[tx_o_indices_idx]);
-			}
-			else
-			{
-				GULPS_LOG_L2("Block is already in blockchain: ", string_tools::pod_to_hex(bl_id));
-			}
-
-			++current_index;
-			++tx_o_indices_idx;
-		}
-	}
-}
 //----------------------------------------------------------------------------------------------------
 void wallet2::refresh()
 {
@@ -1851,34 +1624,6 @@ void wallet2::refresh(uint64_t start_height, uint64_t &blocks_fetched)
 	refresh(start_height, blocks_fetched, received_money);
 }
 //----------------------------------------------------------------------------------------------------
-void wallet2::pull_next_blocks(uint64_t start_height, uint64_t &blocks_start_height, std::list<crypto::hash> &short_chain_history, const std::list<cryptonote::block_complete_entry> &prev_blocks, std::list<cryptonote::block_complete_entry> &blocks, std::vector<cryptonote::COMMAND_RPC_GET_BLOCKS_FAST::block_output_indices> &o_indices, bool &error)
-{
-	error = false;
-
-	try
-	{
-		drop_from_short_history(short_chain_history, 3);
-
-		// prepend the last 3 blocks, should be enough to guard against a block or two's reorg
-		cryptonote::block bl;
-		std::list<cryptonote::block_complete_entry>::const_reverse_iterator i = prev_blocks.rbegin();
-		for(size_t n = 0; n < std::min((size_t)3, prev_blocks.size()); ++n)
-		{
-			bool ok = cryptonote::parse_and_validate_block_from_blob(i->block, bl);
-			THROW_WALLET_EXCEPTION_IF(!ok, error::block_parse_error, i->block);
-			short_chain_history.push_front(cryptonote::get_block_hash(bl));
-			++i;
-		}
-
-		// pull the new blocks
-		pull_blocks(start_height, blocks_start_height, short_chain_history, blocks, o_indices);
-	}
-	catch(...)
-	{
-		error = true;
-	}
-}
-
 void wallet2::remove_obsolete_pool_txs(const std::vector<crypto::hash> &tx_hashes)
 {
 	// remove pool txes to us that aren't in the pool anymore
@@ -2219,20 +1964,96 @@ bool wallet2::delete_address_book_row(std::size_t row_id)
 }
 
 //----------------------------------------------------------------------------------------------------
+void wallet2::integrate_scanned_result(std::unique_ptr<wallet_rpc_scan_data>& res)
+{
+	// First things, first, check for any forks, our data is new so it overrides anything else
+	// Including previous data (can happen if there is a fork during the scan)
+	THROW_WALLET_EXCEPTION_IF(res->blocks_parsed.size() == 0, error::wallet_internal_error, "Integrated blocks vector is empty");
+	THROW_WALLET_EXCEPTION_IF(!m_blockchain.is_in_bounds(res->blocks_parsed.front().block_height), error::wallet_internal_error, "Index out of bounds of hashchain");
+	GULPS_LOGF_L1("Integrating results blocks: {} - {}", res->blocks_parsed.front().block_height, res->blocks_parsed.back().block_height);
+	for(const auto& bl : res->blocks_parsed)
+	{
+		if(bl.block_height >= m_blockchain.size())
+		{
+			m_blockchain.push_back(bl.block_hash);
+			++m_local_bc_height;
+
+			if(0 != m_callback)
+				m_callback->on_new_block(bl.block_height, bl.block);
+		}
+		else if(m_blockchain[bl.block_height] != bl.block_hash)
+		{
+			detach_blockchain(bl.block_height);
+		}
+		else
+		{
+			GULPS_LOG_L2("Block is already in blockchain: ", epee::string_tools::pod_to_hex(bl.block_hash));
+		}
+	}
+
+	// Now, process incoming funds
+	for(const auto& i : res->indices_found)
+	{
+		const cryptonote::block& b = res->blocks_parsed[i.block_idx].block;
+		const std::vector<uint64_t>& tx_indices = res->o_indices[i.block_idx].indices[i.tx_idx].indices;
+		size_t height = res->blocks_parsed[i.block_idx].block_height;
+
+		if(i.tx_idx == 0)
+		{
+			process_new_transaction(get_transaction_hash(b.miner_tx), b.miner_tx, tx_indices, height, b.timestamp, true, false, false);
+		}
+		else
+		{
+			const cryptonote::transaction& tx = res->blocks_parsed[i.block_idx].txes[i.tx_idx-1];
+			process_new_transaction(b.tx_hashes[i.tx_idx-1], tx, tx_indices, height, b.timestamp, false, false, false);
+		}
+	}
+
+	// Do outgoing funds
+	bool needs_full_scan = false;
+	for(const auto& n : m_key_images) 
+	{
+		if(!res->key_images.not_present(&n.first, sizeof(crypto::key_image)))
+		{
+			needs_full_scan = true;
+			break;
+		}
+	}
+
+	if(needs_full_scan)
+	{
+		for(size_t blk_idx = 0; blk_idx < res->blocks_parsed.size(); blk_idx++)
+		{
+			for(size_t tx_idx = 0; tx_idx < res->blocks_parsed[blk_idx].txes.size(); tx_idx++)
+			{
+				for(const auto& in : res->blocks_parsed[blk_idx].txes[tx_idx].vin)
+				{
+					if(in.type() != typeid(cryptonote::txin_to_key))
+						continue;
+
+					if(m_key_images.find(boost::get<cryptonote::txin_to_key>(in).k_image) != m_key_images.end())
+					{
+						const cryptonote::block& b = res->blocks_parsed[blk_idx].block;
+						size_t height = res->blocks_parsed[blk_idx].block_height;
+						const std::vector<uint64_t>& tx_indices = res->o_indices[blk_idx].indices[tx_idx+1].indices;
+						const cryptonote::transaction& tx = res->blocks_parsed[blk_idx].txes[tx_idx];
+						process_new_transaction(b.tx_hashes[tx_idx], tx, tx_indices, height, b.timestamp, false, false, false);
+					}
+				}
+			}
+		}
+	}
+}
+
 void wallet2::refresh(uint64_t start_height, uint64_t &blocks_fetched, bool &received_money)
 {
 	received_money = false;
 	blocks_fetched = 0;
-	uint64_t added_blocks = 0;
-	size_t try_count = 0;
+	size_t entry_height = m_local_bc_height;
 	crypto::hash last_tx_hash_id = m_transfers.size() ? m_transfers.back().m_txid : null_hash;
 	std::list<crypto::hash> short_chain_history;
-	tools::threadpool &tpool = tools::threadpool::getInstance();
-	tools::threadpool::waiter waiter;
+
 	uint64_t blocks_start_height;
-	std::list<cryptonote::block_complete_entry> blocks;
-	std::vector<COMMAND_RPC_GET_BLOCKS_FAST::block_output_indices> o_indices;
-	bool refreshed = false;
 
 	// pull the first set of blocks
 	get_short_chain_history(short_chain_history);
@@ -2253,64 +2074,74 @@ void wallet2::refresh(uint64_t start_height, uint64_t &blocks_fetched, bool &rec
 	// If stop() is called during fast refresh we don't need to continue
 	if(!m_run.load(std::memory_order_relaxed))
 		return;
-	pull_blocks(start_height, blocks_start_height, short_chain_history, blocks, o_indices);
-	// always reset start_height to 0 to force short_chain_ history to be used on
-	// subsequent pulls in this refresh.
-	start_height = 0;
 
-	while(m_run.load(std::memory_order_relaxed))
+	//Download thread will likely be network or disk bound, so it should be in addition to max_conurrency
+	wallet_refresh_ctx refresh_ctx;
+	wallet_block_dl_ctx ctx(refresh_ctx);
+	size_t thd_max = std::min<size_t>(std::thread::hardware_concurrency(), 8);
+	ctx.scan_thd_cnt = thd_max;
+	ctx.short_chain_history = std::move(short_chain_history); //Cant we use ctx.short_chain_history from the beggining? 
+	ctx.start_height = start_height;
+	ctx.thd = std::thread(&wallet2::block_download_thd, this, std::ref(ctx));
+
+	wallet_scan_ctx ct(*this, refresh_ctx);
+	refresh_ctx.m_running_scan_thd_cnt = thd_max;
+	
+	GULPS_LOGF_L1("Running {} scanning threads", refresh_ctx.m_running_scan_thd_cnt);
+
+	std::vector<std::thread> scan_thds;
+	scan_thds.reserve(thd_max);
+	for(size_t i=0; i < thd_max; i++)
+		scan_thds.emplace_back(&wallet2::block_scan_thd, this, std::cref(ct));
+
+	size_t result_idx=0;
+	std::list<std::unique_ptr<wallet2::wallet_rpc_scan_data>> result_list;
+	std::unique_lock<std::mutex> lck;
+	while(refresh_ctx.m_scan_out_queue.wait_for_pop(lck))
 	{
-		try
+		result_list.emplace_back(refresh_ctx.m_scan_out_queue.pop(lck));
+
+		if(!m_run)
+			break;
+
+		bool processed;
+		do
 		{
-			// pull the next set of blocks while we're processing the current one
-			uint64_t next_blocks_start_height;
-			std::list<cryptonote::block_complete_entry> next_blocks;
-			std::vector<cryptonote::COMMAND_RPC_GET_BLOCKS_FAST::block_output_indices> next_o_indices;
-			bool error = false;
-			if(blocks.empty())
+			// Integrate scanned results in order they were fanned out
+			processed = false;
+			for(auto it = result_list.begin(); it != result_list.end();)
 			{
-				refreshed = false;
-				break;
-			}
-			tpool.submit(&waiter, [&] { pull_next_blocks(start_height, next_blocks_start_height, short_chain_history, blocks, next_blocks, next_o_indices, error); });
-
-			process_blocks(blocks_start_height, blocks, o_indices, added_blocks);
-			blocks_fetched += added_blocks;
-			waiter.wait();
-			if(blocks_start_height == next_blocks_start_height)
-			{
-				m_node_rpc_proxy.set_height(m_blockchain.size());
-				refreshed = true;
-				break;
-			}
-
-			// switch to the new blocks from the daemon
-			blocks_start_height = next_blocks_start_height;
-			blocks = next_blocks;
-			o_indices = next_o_indices;
-
-			// handle error from async fetching thread
-			if(error)
-			{
-				throw std::runtime_error("proxy exception in refresh thread");
+				std::unique_ptr<wallet2::wallet_rpc_scan_data>& res = *it;
+				if(result_idx != res->dl_order)
+				{
+					it++;
+					continue;
+				}
+				result_idx++;
+				processed = true;
+				try
+				{
+					integrate_scanned_result(res);
+				}
+				catch(std::exception &e)
+				{
+					GULPS_LOG_ERROR("Integrate scanned results exception:\n", e.what());
+					ctx.error = true;
+					refresh_ctx.m_scan_error = true;
+					m_run = false;
+					break;
+				}
+				it = result_list.erase(it);
 			}
 		}
-		catch(const std::exception &)
-		{
-			blocks_fetched += added_blocks;
-			waiter.wait();
-			if(try_count < 3)
-			{
-				GULPS_LOG_L1("Another try pull_blocks (try_count=", try_count, ")...");
-				++try_count;
-			}
-			else
-			{
-				GULPS_LOG_ERROR("pull_blocks failed, try_count=", try_count);
-				throw;
-			}
-		}
+		while(processed);
 	}
+
+	GULPS_LOG_L1("Joining threads...");
+	ctx.thd.join();
+	for(size_t i=0; i < thd_max; i++)
+		scan_thds[i].join();
+	
 	if(last_tx_hash_id != (m_transfers.size() ? m_transfers.back().m_txid : null_hash))
 		received_money = true;
 
@@ -2318,13 +2149,15 @@ void wallet2::refresh(uint64_t start_height, uint64_t &blocks_fetched, bool &rec
 	{
 		// If stop() is called we don't need to check pending transactions
 		if(m_run.load(std::memory_order_relaxed))
-			update_pool_state(refreshed);
+			update_pool_state(ctx.refreshed);
 	}
 	catch(...)
 	{
 		GULPS_LOG_L1("Failed to check pending transactions");
 	}
 
+	if(m_local_bc_height > entry_height)
+		blocks_fetched = m_local_bc_height - entry_height;
 	GULPS_LOG_L1("Refresh done, blocks received: ", blocks_fetched, ", balance (all accounts): ", print_money(balance_all()), ", unlocked: ", print_money(unlocked_balance_all()));
 }
 //----------------------------------------------------------------------------------------------------

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -2021,6 +2021,18 @@ void wallet2::integrate_scanned_result(std::unique_ptr<wallet_rpc_scan_data>& re
 			break;
 		}
 	}
+	
+	if(!needs_full_scan)
+	{
+		for(const auto& n : res->incoming_kimg) 
+		{
+			if(!res->key_images.not_present(&n, sizeof(crypto::key_image)))
+			{
+				needs_full_scan = true;
+				break;
+			}
+		}
+	}
 
 	if(needs_full_scan)
 	{
@@ -2033,7 +2045,8 @@ void wallet2::integrate_scanned_result(std::unique_ptr<wallet_rpc_scan_data>& re
 					if(in.type() != typeid(cryptonote::txin_to_key))
 						continue;
 
-					if(m_key_images.find(boost::get<cryptonote::txin_to_key>(in).k_image) != m_key_images.end())
+					const crypto::key_image& ki = boost::get<cryptonote::txin_to_key>(in).k_image;
+					if(m_key_images.find(ki) != m_key_images.end() || res->incoming_kimg.find(ki) != res->incoming_kimg.end())
 					{
 						const cryptonote::block& b = res->blocks_parsed[blk_idx].block;
 						size_t height = res->blocks_parsed[blk_idx].block_height;

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -1970,7 +1970,7 @@ void wallet2::integrate_scanned_result(std::unique_ptr<wallet_rpc_scan_data>& re
 	// Including previous data (can happen if there is a fork during the scan)
 	THROW_WALLET_EXCEPTION_IF(res->blocks_parsed.size() == 0, error::wallet_internal_error, "Integrated blocks vector is empty");
 	THROW_WALLET_EXCEPTION_IF(!m_blockchain.is_in_bounds(res->blocks_parsed.front().block_height), error::wallet_internal_error, "Index out of bounds of hashchain");
-	GULPS_LOGF_L1("Integrating results blocks: {} - {}", res->blocks_parsed.front().block_height, res->blocks_parsed.back().block_height);
+	GULPSF_LOG_L1("Integrating results blocks: {} - {}", res->blocks_parsed.front().block_height, res->blocks_parsed.back().block_height);
 	for(const auto& bl : res->blocks_parsed)
 	{
 		if(bl.block_height >= m_blockchain.size())
@@ -2087,7 +2087,7 @@ void wallet2::refresh(uint64_t start_height, uint64_t &blocks_fetched, bool &rec
 	wallet_scan_ctx ct(*this, refresh_ctx);
 	refresh_ctx.m_running_scan_thd_cnt = thd_max;
 	
-	GULPS_LOGF_L1("Running {} scanning threads", refresh_ctx.m_running_scan_thd_cnt);
+	GULPSF_LOG_L1("Running {} scanning threads", refresh_ctx.m_running_scan_thd_cnt);
 
 	std::vector<std::thread> scan_thds;
 	scan_thds.reserve(thd_max);

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -72,6 +72,7 @@
 #include "rpc/core_rpc_server_commands_defs.h"
 #include "storages/http_abstract_invoke.h"
 
+#include "common/bloom_filter.hpp"
 #include "common/password.h"
 #include "node_rpc_proxy.h"
 #include "wallet_errors.h"
@@ -115,7 +116,7 @@ class hashchain
 			m_genesis = hash;
 		m_blockchain.push_back(hash);
 	}
-	bool is_in_bounds(size_t idx) const { return idx >= m_offset && idx < size(); }
+	bool is_in_bounds(size_t idx) const { GULPS_LOGF_L1("is_in_bounds: {} / {} / {}", idx, m_blockchain.size(), m_offset); return idx >= m_offset && idx < size(); }
 	const crypto::hash &operator[](size_t idx) const { return m_blockchain[idx - m_offset]; }
 	crypto::hash &operator[](size_t idx) { return m_blockchain[idx - m_offset]; }
 	void crop(size_t height) { m_blockchain.resize(height - m_offset); }
@@ -1088,16 +1089,12 @@ class wallet2
      */
 	bool load_keys(const std::string &keys_file_name, const epee::wipeable_string &password);
 	void process_new_transaction(const crypto::hash &txid, const cryptonote::transaction &tx, const std::vector<uint64_t> &o_indices, uint64_t height, uint64_t ts, bool miner_tx, bool pool, bool double_spend_seen);
-	void process_new_blockchain_entry(const cryptonote::block &b, const cryptonote::block_complete_entry &bche, const crypto::hash &bl_id, uint64_t height, const cryptonote::COMMAND_RPC_GET_BLOCKS_FAST::block_output_indices &o_indices);
 	void detach_blockchain(uint64_t height);
 	void get_short_chain_history(std::list<crypto::hash> &ids) const;
 	bool is_tx_spendtime_unlocked(uint64_t unlock_time, uint64_t block_height) const;
 	bool clear();
-	void pull_blocks(uint64_t start_height, uint64_t &blocks_start_height, const std::list<crypto::hash> &short_chain_history, std::list<cryptonote::block_complete_entry> &blocks, std::vector<cryptonote::COMMAND_RPC_GET_BLOCKS_FAST::block_output_indices> &o_indices);
 	void pull_hashes(uint64_t start_height, uint64_t &blocks_start_height, const std::list<crypto::hash> &short_chain_history, std::list<crypto::hash> &hashes);
 	void fast_refresh(uint64_t stop_height, uint64_t &blocks_start_height, std::list<crypto::hash> &short_chain_history);
-	void pull_next_blocks(uint64_t start_height, uint64_t &blocks_start_height, std::list<crypto::hash> &short_chain_history, const std::list<cryptonote::block_complete_entry> &prev_blocks, std::list<cryptonote::block_complete_entry> &blocks, std::vector<cryptonote::COMMAND_RPC_GET_BLOCKS_FAST::block_output_indices> &o_indices, bool &error);
-	void process_blocks(uint64_t start_height, const std::list<cryptonote::block_complete_entry> &blocks, const std::vector<cryptonote::COMMAND_RPC_GET_BLOCKS_FAST::block_output_indices> &o_indices, uint64_t &blocks_added);
 	uint64_t select_transfers(uint64_t needed_money, std::vector<size_t> unused_transfers_indices, std::vector<size_t> &selected_transfers, bool trusted_daemon) const;
 	bool prepare_file_names(const std::string &file_path);
 	void process_unconfirmed(const crypto::hash &txid, const cryptonote::transaction &tx, uint64_t height);
@@ -1228,6 +1225,87 @@ class wallet2
 	std::string m_ring_database;
 	bool m_ring_history_saved;
 	std::unique_ptr<ringdb> m_ringdb;
+
+	struct wallet_rpc_scan_data
+	{
+		struct block_complete_entry_parsed
+		{
+			uint64_t block_height;
+			crypto::hash block_hash;
+			cryptonote::block block;
+			std::vector<cryptonote::transaction> txes;
+			bool skipped;
+		};
+
+		struct found_output_idx
+		{
+			found_output_idx(size_t block_idx, size_t tx_idx) : block_idx(block_idx), tx_idx(tx_idx) {}
+			size_t block_idx;
+			size_t tx_idx;
+		};
+
+		size_t dl_order;
+		uint64_t blocks_start_height;
+		const std::list<crypto::hash> short_chain_history;
+		std::list<cryptonote::block_complete_entry> blocks_bin;
+		std::vector<cryptonote::COMMAND_RPC_GET_BLOCKS_FAST::block_output_indices> o_indices;
+
+		std::vector<block_complete_entry_parsed> blocks_parsed;
+		std::vector<found_output_idx> indices_found;
+		bloom_filter key_images;
+	};
+
+	std::unique_ptr<wallet_rpc_scan_data> pull_blocks(uint64_t start_height, const std::list<crypto::hash> &short_chain_history);
+
+	struct wallet_refresh_ctx
+	{
+		wallet_refresh_ctx() : m_scan_error(false) {};
+
+		thdq<std::unique_ptr<wallet_rpc_scan_data>> m_scan_in_queue;
+		thdq<std::unique_ptr<wallet_rpc_scan_data>> m_scan_out_queue;
+		std::atomic<size_t> m_running_scan_thd_cnt;
+		std::atomic<bool> m_scan_error;
+	};
+
+	struct wallet_scan_ctx
+	{
+		wallet_scan_ctx(const wallet2& parent, wallet_refresh_ctx& refresh_ctx) : 
+			explicit_refresh(parent.m_explicit_refresh_from_block_height),
+			wallet_create_time(parent.m_account.get_createtime()),
+			refresh_height(parent.m_refresh_from_block_height),
+			account(parent.m_account),
+			scan_type(parent.m_refresh_type),
+			refresh_ctx(refresh_ctx)
+			{}
+
+		bool explicit_refresh;
+		uint64_t wallet_create_time;
+		uint64_t refresh_height;
+		const cryptonote::account_base& account;
+		RefreshType scan_type;
+		wallet_refresh_ctx& refresh_ctx;
+	};
+
+	struct wallet_block_dl_ctx
+	{
+		wallet_block_dl_ctx(wallet_refresh_ctx& refresh_ctx) : 
+			refresh_ctx(refresh_ctx) {}
+
+		size_t scan_thd_cnt;
+		size_t start_height;
+		std::list<crypto::hash> short_chain_history;
+
+		std::thread thd;
+		std::atomic<bool> error;
+		bool refreshed;
+		bool cancelled;
+		wallet_refresh_ctx& refresh_ctx;
+	};
+
+	void integrate_scanned_result(std::unique_ptr<wallet_rpc_scan_data>& res);
+	void block_download_thd(wallet2::wallet_block_dl_ctx& ctx);
+	void block_scan_thd(const wallet_scan_ctx& ctx);
+	bool block_scan_tx(const wallet_scan_ctx& ctx, const crypto::hash& txid, const cryptonote::transaction& tx, bloom_filter& in_kimg);
 };
 }
 BOOST_CLASS_VERSION(tools::wallet2, 24)
@@ -1246,6 +1324,20 @@ BOOST_CLASS_VERSION(tools::wallet2::signed_tx_set, 0)
 BOOST_CLASS_VERSION(tools::wallet2::tx_construction_data, 3)
 BOOST_CLASS_VERSION(tools::wallet2::pending_tx, 3)
 BOOST_CLASS_VERSION(tools::wallet2::multisig_sig, 0)
+
+inline void drop_from_short_history(std::list<crypto::hash> &short_chain_history, size_t N)
+{
+	std::list<crypto::hash>::iterator right;
+	// drop early N off, skipping the genesis block
+	if(short_chain_history.size() > N)
+	{
+		right = short_chain_history.end();
+		std::advance(right, -1);
+		std::list<crypto::hash>::iterator left = right;
+		std::advance(left, -N);
+		short_chain_history.erase(left, right);
+	}
+}
 
 namespace boost
 {

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -1234,6 +1234,7 @@ class wallet2
 			uint64_t block_height;
 			crypto::hash block_hash;
 			cryptonote::block block;
+			crypto::hash miner_tx_hash;
 			std::vector<cryptonote::transaction> txes;
 			bool skipped;
 		};

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -1247,7 +1247,7 @@ class wallet2
 		size_t dl_order;
 		uint64_t blocks_start_height;
 		const std::list<crypto::hash> short_chain_history;
-		std::list<cryptonote::block_complete_entry> blocks_bin;
+		std::vector<cryptonote::block_complete_entry_v> blocks_bin;
 		std::vector<cryptonote::COMMAND_RPC_GET_BLOCKS_FAST::block_output_indices> o_indices;
 
 		std::vector<block_complete_entry_parsed> blocks_parsed;

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -1255,6 +1255,7 @@ class wallet2
 		std::vector<block_complete_entry_parsed> blocks_parsed;
 		std::vector<found_output_idx> indices_found;
 		bloom_filter key_images;
+		std::unordered_set<crypto::key_image> incoming_kimg;
 	};
 
 	std::unique_ptr<wallet_rpc_scan_data> pull_blocks(uint64_t start_height, const std::list<crypto::hash> &short_chain_history);
@@ -1307,7 +1308,7 @@ class wallet2
 	void integrate_scanned_result(std::unique_ptr<wallet_rpc_scan_data>& res);
 	void block_download_thd(wallet2::wallet_block_dl_ctx& ctx);
 	void block_scan_thd(const wallet_scan_ctx& ctx);
-	bool block_scan_tx(const wallet_scan_ctx& ctx, const crypto::hash& txid, const cryptonote::transaction& tx, bloom_filter& in_kimg);
+	bool block_scan_tx(const wallet_scan_ctx& ctx, const crypto::hash& txid, const cryptonote::transaction& tx, bloom_filter& in_kimg, std::unordered_set<crypto::key_image>& inc_kimg);
 	using tx_call_map = std::unordered_map<crypto::hash, std::pair<std::function<void()>, uint64_t>>;
 	inline void add_new_tx_call(tx_call_map& map, const crypto::hash& txid, const cryptonote::transaction& tx, const std::vector<uint64_t>& o_indices, 
 								uint64_t height, uint64_t ts, bool miner_tx)

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -1308,6 +1308,16 @@ class wallet2
 	void block_download_thd(wallet2::wallet_block_dl_ctx& ctx);
 	void block_scan_thd(const wallet_scan_ctx& ctx);
 	bool block_scan_tx(const wallet_scan_ctx& ctx, const crypto::hash& txid, const cryptonote::transaction& tx, bloom_filter& in_kimg);
+	using tx_call_map = std::unordered_map<crypto::hash, std::pair<std::function<void()>, uint64_t>>;
+	inline void add_new_tx_call(tx_call_map& map, const crypto::hash& txid, const cryptonote::transaction& tx, const std::vector<uint64_t>& o_indices, 
+								uint64_t height, uint64_t ts, bool miner_tx)
+	{
+		if(map.find(txid) != map.end())
+			return;
+
+		map.emplace(std::piecewise_construct, std::forward_as_tuple(txid), std::forward_as_tuple(
+			std::bind(&wallet2::process_new_transaction, this, std::cref(txid), std::cref(tx), std::cref(o_indices), height, ts, miner_tx, false, false), height));
+	}
 };
 }
 BOOST_CLASS_VERSION(tools::wallet2, 24)

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -104,7 +104,8 @@ class i_wallet2_callback
 
 class hashchain
 {
-  public:
+GULPS_CAT_MAJOR("wallet2");
+public:
 	hashchain() : m_genesis(crypto::null_hash), m_offset(0) {}
 
 	size_t size() const { return m_blockchain.size() + m_offset; }
@@ -116,7 +117,7 @@ class hashchain
 			m_genesis = hash;
 		m_blockchain.push_back(hash);
 	}
-	bool is_in_bounds(size_t idx) const { GULPS_LOGF_L1("is_in_bounds: {} / {} / {}", idx, m_blockchain.size(), m_offset); return idx >= m_offset && idx < size(); }
+	bool is_in_bounds(size_t idx) const { GULPSF_LOG_L1("is_in_bounds: {} / {} / {}", idx, m_blockchain.size(), m_offset); return idx >= m_offset && idx < size(); }
 	const crypto::hash &operator[](size_t idx) const { return m_blockchain[idx - m_offset]; }
 	crypto::hash &operator[](size_t idx) { return m_blockchain[idx - m_offset]; }
 	void crop(size_t height) { m_blockchain.resize(height - m_offset); }

--- a/src/wallet/wallet2_tx_scan.cpp
+++ b/src/wallet/wallet2_tx_scan.cpp
@@ -43,6 +43,8 @@
 
 namespace tools
 {
+GULPS_CAT_MAJOR("wallet_tx_scan");
+
 std::unique_ptr<wallet2::wallet_rpc_scan_data> wallet2::pull_blocks(uint64_t start_height, const std::list<crypto::hash> &short_chain_history)
 {
 	cryptonote::COMMAND_RPC_GET_BLOCKS_FAST::request req = AUTO_VAL_INIT(req);
@@ -60,7 +62,7 @@ std::unique_ptr<wallet2::wallet_rpc_scan_data> wallet2::pull_blocks(uint64_t sta
 							  "mismatched blocks (" + boost::lexical_cast<std::string>(res.blocks.size()) + ") and output_indices (" +
 								  boost::lexical_cast<std::string>(res.output_indices.size()) + ") sizes from daemon");
 
-	GULPS_LOGF_L1("Pulled blocks {}-{} / {}.", res.start_height, std::max(res.start_height+res.blocks.size()-1, res.start_height), res.current_height);
+	GULPSF_LOG_L1("Pulled blocks {}-{} / {}.", res.start_height, std::max(res.start_height+res.blocks.size()-1, res.start_height), res.current_height);
 
 	std::unique_ptr<wallet2::wallet_rpc_scan_data> ret(new wallet_rpc_scan_data);
 	ret->blocks_start_height = res.start_height;
@@ -99,7 +101,7 @@ void wallet2::block_download_thd(wallet2::wallet_block_dl_ctx& ctx)
 			current_top_height = pull_res->blocks_start_height + pull_res->blocks_bin.size()-1;
 			if(last_top_height == current_top_height)
 			{
-				GULPS_LOGF_L1("No more blocks from daemon.");
+				GULPS_LOG_L1("No more blocks from daemon.");
 				ctx.refresh_ctx.m_scan_in_queue.set_finish_flag();
 				ctx.refreshed = true; 
 				return;
@@ -150,12 +152,12 @@ void wallet2::block_download_thd(wallet2::wallet_block_dl_ctx& ctx)
 	ctx.refresh_ctx.m_scan_in_queue.set_finish_flag();
 	if(ctx.error)
 	{
-		GULPS_LOGF_L1("Stop downloading blocks due to an error");
+		GULPS_LOG_L1("Stop downloading blocks due to an error");
 	}
 	else
 	{
 		ctx.cancelled = true;
-		GULPS_LOGF_L1("Stop downloading blocks due to user cancel");
+		GULPS_LOG_L1("Stop downloading blocks due to user cancel");
 	}
 }
 
@@ -273,7 +275,7 @@ void wallet2::block_scan_thd(const wallet_scan_ctx& ctx)
 		{
 			std::unique_ptr<wallet2::wallet_rpc_scan_data> pull_res = ctx.refresh_ctx.m_scan_in_queue.pop(lck);
 
-			GULPS_LOGF_L1("Scanning blocks {} - {}", pull_res->blocks_start_height, pull_res->blocks_start_height+pull_res->blocks_bin.size()-1);
+			GULPSF_LOG_L1("Scanning blocks {} - {}", pull_res->blocks_start_height, pull_res->blocks_start_height+pull_res->blocks_bin.size()-1);
 			
 			if(ctx.refresh_ctx.m_scan_error)
 			{
@@ -353,19 +355,19 @@ void wallet2::block_scan_thd(const wallet_scan_ctx& ctx)
 	{
 		ctx.refresh_ctx.m_scan_error = true;
 		m_run = false;
-		GULPS_LOG_ERROR("Blocks scanning thread exception: {}", e.what());
+		GULPSF_LOG_ERROR("Blocks scanning thread exception: {}", e.what());
 	}
 
 	if(ctx.refresh_ctx.m_running_scan_thd_cnt.fetch_sub(1)-1 == 0)
 	{
-		GULPS_LOGF_L1("Blocks scanning threads complete");
+		GULPS_LOG_L1("Blocks scanning threads complete");
 		ctx.refresh_ctx.m_scan_out_queue.set_finish_flag();
 	}
 	else
 	{
 		size_t left = ctx.refresh_ctx.m_running_scan_thd_cnt;
 		bool error = ctx.refresh_ctx.m_scan_error;
-		GULPS_LOG_L1("block_scan_thd exits {} left, m_scan_error state", left, error);
+		GULPSF_LOG_L1("block_scan_thd exits {} left, m_scan_error state", left, error);
 	}
 }
 }

--- a/src/wallet/wallet2_tx_scan.cpp
+++ b/src/wallet/wallet2_tx_scan.cpp
@@ -286,7 +286,7 @@ void wallet2::block_scan_thd(const wallet_scan_ctx& ctx)
 			size_t blk_i=0;
 			size_t in_count = 0;
 			pull_res->blocks_parsed.resize(pull_res->blocks_bin.size());
-			for(const cryptonote::block_complete_entry& bl : pull_res->blocks_bin)
+			for(const cryptonote::block_complete_entry_v& bl : pull_res->blocks_bin)
 			{
 				wallet_rpc_scan_data::block_complete_entry_parsed& blke = pull_res->blocks_parsed[blk_i];
 				const cryptonote::COMMAND_RPC_GET_BLOCKS_FAST::block_output_indices& blk_o_idx = pull_res->o_indices[blk_i];

--- a/src/wallet/wallet2_tx_scan.cpp
+++ b/src/wallet/wallet2_tx_scan.cpp
@@ -1,0 +1,371 @@
+// Copyright (c) 2019, Ryo Currency Project
+//
+// Authors and copyright holders give permission for following:
+//
+// 1. Redistribution and use in source and binary forms WITHOUT modification.
+//
+// 2. Modification of the source form for your own personal use.
+//
+// As long as the following conditions are met:
+//
+// 3. You must not distribute modified copies of the work to third parties. This includes
+//    posting the work online, or hosting copies of the modified work for download.
+//
+// 4. Any derivative version of this work is also covered by this license, including point 8.
+//
+// 5. Neither the name of the copyright holders nor the names of the authors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// 6. You agree that this licence is governed by and shall be construed in accordance
+//    with the laws of England and Wales.
+//
+// 7. You agree to submit all disputes arising out of or in connection with this licence
+//    to the exclusive jurisdiction of the Courts of England and Wales.
+//
+// Authors and copyright holders agree that:
+//
+// 8. This licence expires and the work covered by it is released into the
+//    public domain on 1st of February 2020
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "wallet2.h"
+#include "crypto/crypto.h"
+
+namespace tools
+{
+std::unique_ptr<wallet2::wallet_rpc_scan_data> wallet2::pull_blocks(uint64_t start_height, const std::list<crypto::hash> &short_chain_history)
+{
+	cryptonote::COMMAND_RPC_GET_BLOCKS_FAST::request req = AUTO_VAL_INIT(req);
+	cryptonote::COMMAND_RPC_GET_BLOCKS_FAST::response res = AUTO_VAL_INIT(res);
+	req.block_ids = short_chain_history;
+	req.prune = true;
+	req.start_height = start_height;
+	m_daemon_rpc_mutex.lock();
+	bool r = epee::net_utils::invoke_http_bin("/getblocks.bin", req, res, m_http_client, rpc_timeout);
+	m_daemon_rpc_mutex.unlock();
+	THROW_WALLET_EXCEPTION_IF(!r, error::no_connection_to_daemon, "getblocks.bin");
+	THROW_WALLET_EXCEPTION_IF(res.status == CORE_RPC_STATUS_BUSY, error::daemon_busy, "getblocks.bin");
+	THROW_WALLET_EXCEPTION_IF(res.status != CORE_RPC_STATUS_OK, error::get_blocks_error, res.status);
+	THROW_WALLET_EXCEPTION_IF(res.blocks.size() != res.output_indices.size(), error::wallet_internal_error,
+							  "mismatched blocks (" + boost::lexical_cast<std::string>(res.blocks.size()) + ") and output_indices (" +
+								  boost::lexical_cast<std::string>(res.output_indices.size()) + ") sizes from daemon");
+
+	GULPS_LOGF_L1("Pulled blocks {}-{} / {}.", res.start_height, std::max(res.start_height+res.blocks.size()-1, res.start_height), res.current_height);
+
+	std::unique_ptr<wallet2::wallet_rpc_scan_data> ret(new wallet_rpc_scan_data);
+	ret->blocks_start_height = res.start_height;
+	ret->blocks_bin = std::move(res.blocks);
+	ret->o_indices = std::move(res.output_indices);
+	return ret;
+}
+
+void wallet2::block_download_thd(wallet2::wallet_block_dl_ctx& ctx)
+{
+	size_t try_count = 0;
+	size_t last_top_height = 0;
+	size_t current_top_height = 0;
+	bool first_round = true;
+	std::unique_ptr<wallet2::wallet_rpc_scan_data> pull_res;
+	ctx.refreshed = false;
+	ctx.error = false;
+	ctx.cancelled = false;
+	size_t dl_order = 0;
+
+	while(m_run.load(std::memory_order_relaxed))
+	{
+		try
+		{
+			GULPS_LOG_L1("Pulling blocks...");
+			pull_res = pull_blocks(ctx.start_height, ctx.short_chain_history);
+
+			if(pull_res->blocks_bin.empty())
+			{
+				// TODO store short_chain_history or last height to retry pulling blocks
+				GULPS_LOG_ERROR("Empty blocks vector from daemon.");
+				try_count = 3;
+				throw std::exception();
+			}
+
+			current_top_height = pull_res->blocks_start_height + pull_res->blocks_bin.size()-1;
+			if(last_top_height == current_top_height)
+			{
+				GULPS_LOGF_L1("No more blocks from daemon.");
+				ctx.refresh_ctx.m_scan_in_queue.set_finish_flag();
+				ctx.refreshed = true; 
+				return;
+			}
+
+			last_top_height = current_top_height;
+			pull_res->dl_order = dl_order++;
+			if(first_round)
+			{
+				// Use chain history from now on
+				ctx.start_height = 0;
+				first_round = false;
+			}
+	
+			drop_from_short_history(ctx.short_chain_history, 3);
+			// prepend the last 3 blocks, should be enough to guard against a block or two's reorg
+			cryptonote::block bl;
+			for(auto it=pull_res->blocks_bin.rbegin(); it != pull_res->blocks_bin.rend() && std::distance(pull_res->blocks_bin.rbegin(), it) < 3; ++it)
+			{
+				bool ok = cryptonote::parse_and_validate_block_from_blob(it->block, bl);
+				THROW_WALLET_EXCEPTION_IF(!ok, error::block_parse_error, it->block);
+				ctx.short_chain_history.push_front(cryptonote::get_block_hash(bl));
+			}
+
+			ctx.refresh_ctx.m_scan_in_queue.wait_for_size(ctx.scan_thd_cnt + 1);
+			ctx.refresh_ctx.m_scan_in_queue.push(std::move(pull_res));
+			GULPS_LOG_L1("Pushed blocks...");
+		}
+		catch(...)
+		{
+			if(try_count < 3)
+			{
+				GULPS_LOG_L1("Another try pull_blocks (try_count=", try_count, ")...");
+				++try_count;
+			}
+			else
+			{
+				GULPS_LOG_ERROR("pull_blocks failed, try_count=", try_count);
+
+				// Exit due to an error
+				ctx.refresh_ctx.m_scan_in_queue.set_finish_flag();
+				ctx.error = true;
+				return;
+			}
+		}
+	}
+
+	ctx.refresh_ctx.m_scan_in_queue.set_finish_flag();
+	if(ctx.error)
+	{
+		GULPS_LOGF_L1("Stop downloading blocks due to an error");
+	}
+	else
+	{
+		ctx.cancelled = true;
+		GULPS_LOGF_L1("Stop downloading blocks due to user cancel");
+	}
+}
+
+bool wallet2::block_scan_tx(const wallet_scan_ctx& ctx, const crypto::hash& txid, const cryptonote::transaction& tx, bloom_filter& in_kimg)
+{
+	const cryptonote::account_keys &keys = ctx.account.get_keys();
+	GULPS_LOG_L2("Scanning tx ", txid);
+	for(size_t in_idx = 0; in_idx < tx.vin.size(); in_idx++)
+	{
+		if(tx.vin[in_idx].type() != typeid(cryptonote::txin_to_key))
+			continue;
+
+		const crypto::key_image& ki = boost::get<cryptonote::txin_to_key>(tx.vin[in_idx]).k_image;
+		in_kimg.add_element(&ki, sizeof(crypto::key_image));
+	}
+
+	std::vector<cryptonote::tx_extra_field> tx_extra_fields;
+	if(!parse_tx_extra(tx.extra, tx_extra_fields))
+	{
+		// Extra may only be partially parsed, it's OK if tx_extra_fields contains public key
+		GULPS_LOG_L0("Transaction extra has unsupported format: ", txid);
+	}
+
+	cryptonote::tx_extra_pub_key pub_key_field;
+	if(!find_tx_extra_field_by_type(tx_extra_fields, pub_key_field))
+	{
+		GULPS_LOG_L0("Public key wasn't found in the transaction extra. Skipping transaction ", txid);
+		return false;
+	}
+
+	const crypto::public_key& tx_pub_key = pub_key_field.pub_key;
+	crypto::key_derivation derivation;
+	bool derivation_res;
+#ifdef HAVE_EC_64
+	derivation_res = crypto::generate_key_derivation_64(tx_pub_key, keys.m_view_secret_key, derivation);
+#else
+	derivation_res = crypto::generate_key_derivation(tx_pub_key, keys.m_view_secret_key, derivation);
+#endif
+	
+	if(!derivation_res)
+	{
+		GULPS_WARN("Failed to generate key derivation from tx pubkey, skipping");
+		memcpy(&derivation, rct::identity().bytes, sizeof(derivation));
+	}
+
+	std::vector<crypto::public_key> additional_tx_pub_keys = get_additional_tx_pub_keys_from_extra(tx);
+	std::vector<crypto::key_derivation> additional_derivations;
+	additional_derivations.resize(additional_tx_pub_keys.size());
+
+	// additional tx pubkeys and derivations for multi-destination transfers involving one or more subaddresses
+	for(size_t i = 0; i < additional_tx_pub_keys.size(); ++i)
+	{
+#ifdef HAVE_EC_64
+		derivation_res = crypto::generate_key_derivation_64(additional_tx_pub_keys[i], keys.m_view_secret_key, additional_derivations[i]);
+#else
+		derivation_res = crypto::generate_key_derivation(additional_tx_pub_keys[i], keys.m_view_secret_key, additional_derivations[i]);
+#endif
+		if(!derivation_res)
+		{
+			GULPS_WARN("Failed to generate key derivation from extra pubkey ", i, ", skipping");
+			additional_derivations.pop_back();
+		}
+	}
+
+	for(size_t out_idx = 0; out_idx < tx.vout.size(); out_idx++)
+	{
+		if(tx.vout[out_idx].target.type() != typeid(cryptonote::txout_to_key))
+		{
+			GULPS_LOG_L0("Wrong type id in transaction out");
+			continue;
+		}
+
+		// try the shared tx pubkey
+		crypto::public_key subaddress_spendkey;
+		const crypto::public_key& out_pubkey = boost::get<cryptonote::txout_to_key>(tx.vout[out_idx].target).key;
+#ifdef HAVE_EC_64
+		crypto::derive_subaddress_public_key_64(out_pubkey, derivation, out_idx, subaddress_spendkey);
+#else
+		crypto::derive_subaddress_public_key(out_pubkey, derivation, out_idx, subaddress_spendkey);
+#endif
+		
+
+		auto found = m_subaddresses.find(subaddress_spendkey);
+		if(found != m_subaddresses.end())
+			return true;
+
+		// try additional tx pubkeys if available
+		if(!additional_derivations.empty())
+		{
+			if(out_idx >= additional_derivations.size())
+			{
+				GULPS_LOG_L0("Wrong number of additional derivations");
+				return false;
+			}
+#ifdef HAVE_EC_64
+			crypto::derive_subaddress_public_key_64(out_pubkey, additional_derivations[out_idx], out_idx, subaddress_spendkey);
+#else
+			crypto::derive_subaddress_public_key(out_pubkey, additional_derivations[out_idx], out_idx, subaddress_spendkey);
+#endif
+			found = m_subaddresses.find(subaddress_spendkey);
+			if(found != m_subaddresses.end())
+				return true;
+		}
+	}
+
+	return false;
+}
+
+void wallet2::block_scan_thd(const wallet_scan_ctx& ctx)
+{
+	try
+	{
+		std::unique_lock<std::mutex> lck;
+		while(ctx.refresh_ctx.m_scan_in_queue.wait_for_pop(lck))
+		{
+			std::unique_ptr<wallet2::wallet_rpc_scan_data> pull_res = ctx.refresh_ctx.m_scan_in_queue.pop(lck);
+
+			GULPS_LOGF_L1("Scanning blocks {} - {}", pull_res->blocks_start_height, pull_res->blocks_start_height+pull_res->blocks_bin.size()-1);
+			
+			if(ctx.refresh_ctx.m_scan_error)
+			{
+				GULPS_LOG_L1("block_scan_thd exits due to m_scan_error.");
+				break;
+			}
+
+			THROW_WALLET_EXCEPTION_IF(pull_res->blocks_bin.size() != pull_res->o_indices.size(), error::wallet_internal_error, "size mismatch");
+
+			size_t blk_i=0;
+			size_t in_count = 0;
+			pull_res->blocks_parsed.resize(pull_res->blocks_bin.size());
+			for(const cryptonote::block_complete_entry& bl : pull_res->blocks_bin)
+			{
+				wallet_rpc_scan_data::block_complete_entry_parsed& blke = pull_res->blocks_parsed[blk_i];
+				const cryptonote::COMMAND_RPC_GET_BLOCKS_FAST::block_output_indices& blk_o_idx = pull_res->o_indices[blk_i];
+				blke.block_height = pull_res->blocks_start_height + blk_i;
+
+				bool r = cryptonote::parse_and_validate_block_from_blob(bl.block, blke.block);
+				THROW_WALLET_EXCEPTION_IF(!r, error::block_parse_error, bl.block);
+				blke.block_hash = get_block_hash(blke.block);
+				THROW_WALLET_EXCEPTION_IF(bl.txs.size() + 1 != blk_o_idx.indices.size(), error::wallet_internal_error,
+					"block transactions=" + std::to_string(bl.txs.size()) + " not match with daemon response size=" + 
+					std::to_string(blk_o_idx.indices.size()) + " for block " + std::to_string(blke.block_height));
+				THROW_WALLET_EXCEPTION_IF(bl.txs.size() != blke.block.tx_hashes.size(), error::wallet_internal_error, 
+										  "Wrong amount of transactions for block");
+
+				blk_i++;
+				if(!ctx.explicit_refresh && (blke.block.timestamp + 60 * 60 * 24 <= ctx.wallet_create_time || blke.block_height  < ctx.refresh_height))
+				{
+					if(blke.block_height % 100 == 0)
+						GULPS_LOG_L2("Skipped block by timestamp, height: ", blke.block_height, ", block time ", 
+									 blke.block.timestamp, ", account time ", ctx.wallet_create_time);
+					blke.skipped = true;
+					continue;
+				}
+				blke.skipped = false;
+
+				size_t tx_i =0;
+				blke.txes.resize(bl.txs.size());
+				for(const cryptonote::blobdata& tx_blob : bl.txs)
+				{
+					cryptonote::transaction& tx = blke.txes[tx_i];
+					bool r = parse_and_validate_tx_base_from_blob(tx_blob, tx);
+					THROW_WALLET_EXCEPTION_IF(!r, error::tx_parse_error, tx_blob);
+					in_count += tx.vin.size();
+					tx_i++;
+				}
+			}
+
+			pull_res->key_images.init(in_count);
+			for(size_t i=0; i < blk_i; i++)
+			{
+				wallet_rpc_scan_data::block_complete_entry_parsed& blke = pull_res->blocks_parsed[i];
+
+				if(blke.skipped)
+					continue;
+
+				if(ctx.scan_type != RefreshNoCoinbase)
+				{
+					crypto::hash txid = cryptonote::get_transaction_hash(blke.block.miner_tx);
+					if(block_scan_tx(ctx, txid, blke.block.miner_tx, pull_res->key_images))
+						pull_res->indices_found.emplace_back(i, 0);
+				}
+
+				for(size_t txi=0; txi < blke.txes.size(); txi++)
+				{
+					if(block_scan_tx(ctx, blke.block.tx_hashes[txi], blke.txes[txi], pull_res->key_images))
+						pull_res->indices_found.emplace_back(i, txi+1);
+				}
+			}
+
+			ctx.refresh_ctx.m_scan_out_queue.push(std::move(pull_res));
+		}
+	}
+	catch(std::exception& e)
+	{
+		ctx.refresh_ctx.m_scan_error = true;
+		m_run = false;
+		GULPS_LOG_ERROR("Blocks scanning thread exception: {}", e.what());
+	}
+
+	if(ctx.refresh_ctx.m_running_scan_thd_cnt.fetch_sub(1)-1 == 0)
+	{
+		GULPS_LOGF_L1("Blocks scanning threads complete");
+		ctx.refresh_ctx.m_scan_out_queue.set_finish_flag();
+	}
+	else
+	{
+		size_t left = ctx.refresh_ctx.m_running_scan_thd_cnt;
+		bool error = ctx.refresh_ctx.m_scan_error;
+		GULPS_LOG_L1("block_scan_thd exits {} left, m_scan_error state", left, error);
+	}
+}
+}

--- a/tests/unit_tests/hardfork.cpp
+++ b/tests/unit_tests/hardfork.cpp
@@ -64,6 +64,7 @@ class TestDB : public BlockchainDB
 	virtual blobdata get_block_blob_from_height(const uint64_t &height) const { return cryptonote::t_serializable_object_to_blob(get_block_from_height(height)); }
 	virtual blobdata get_block_blob(const crypto::hash &h) const { return blobdata(); }
 	virtual bool get_tx_blob(const crypto::hash &h, cryptonote::blobdata &tx) const { return false; }
+	virtual bool get_tx_blob_indexed(const crypto::hash& h, cryptonote::blobdata& bd, std::vector<uint64_t>& o_idx) const { return false; }
 	virtual uint64_t get_block_height(const crypto::hash &h) const { return 0; }
 	virtual block_header get_block_header(const crypto::hash &h) const { return block_header(); }
 	virtual uint64_t get_block_timestamp(const uint64_t &height) const { return 0; }


### PR DESCRIPTION
Upgrade multithreading in the wallet to something that has actually a fighting chance of maxing out the CPU.

- Use of 64 bit lib is conservative, there is no way to produce anything but false negatives if there is an exploitable problem there.
- We strip away the abstraction layers in 64 bit code (mostly to avoid giving a blueprint for a parallel hw wallet implementation to guys that should really have been able to figure it out on their own)
- Bottleneck now is the block feed speed
- Time improvement will vary depending on the point above. HDDs won't see a lot. High IOPS NVMe SSDs will improve most. Overall 2 to 5x is a good ballpark figure so far.