### PR TITLE
Fix disparities and edge cases in log-file-level

### DIFF
--- a/src/daemon/command_line_args.h
+++ b/src/daemon/command_line_args.h
@@ -74,7 +74,7 @@ const command_line::arg_descriptor<std::string, false, true, 2> arg_log_file = {
 const command_line::arg_descriptor<std::string> arg_log_level = {
 	"log-level", "Screen log level", ""};
 const command_line::arg_descriptor<std::string> arg_log_file_level = {
-	"file-log-level", "File log level", ""};
+	"log-file-level", "File log level", ""};
 const command_line::arg_descriptor<std::vector<std::string>> arg_command = {
 	"daemon_command", "Hidden"};
 const command_line::arg_descriptor<bool> arg_os_version = {

--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -261,6 +261,12 @@ int main(int argc, char* argv[])
 			}
 		}
 
+		if(!command_line::is_arg_defaulted(vm, daemon_args::arg_log_file) && command_line::is_arg_defaulted(vm, daemon_args::arg_log_file_level))
+		{
+			GULPSF_PRINT("Argument log-file is set, but log-file-level is not. Defaulting log-file-level to 2");
+			log_dsk.parse_cat_string("*:INFO");
+		}
+
 		// If there are positional options, we're running a daemon command
 		{
 			gulps::inst().remove_output(temp_out_id);

--- a/src/wallet/wallet_args.cpp
+++ b/src/wallet/wallet_args.cpp
@@ -183,11 +183,20 @@ boost::optional<boost::program_options::variables_map> main(
 			}
 		}
 
-		if(!command_line::is_arg_defaulted(vm, arg_file_level))
+		if(!command_line::is_arg_defaulted(vm, arg_log_file) || !command_line::is_arg_defaulted(vm, arg_file_level))
 		{
-			if(!log_dsk.parse_cat_string(command_line::get_arg(vm, arg_file_level).c_str()))
+			const char* arg_file_str;
+			if(command_line::is_arg_defaulted(vm, arg_file_level))
 			{
-				GULPS_ERROR(wallet_args::tr("Failed to parse filter string "), command_line::get_arg(vm, arg_file_level).c_str());
+				GULPSF_PRINT("Argument log-file is set, but log-file-level is not. Defaulting log-file-level to 2");
+				arg_file_str = "*:INFO";
+			}
+			else
+				arg_file_str = command_line::get_arg(vm, arg_file_level).c_str();
+
+			if(!log_dsk.parse_cat_string(arg_file_str))
+			{
+				GULPS_ERROR(wallet_args::tr("Failed to parse filter string "), arg_file_str);
 				return false;
 			}
 


### PR DESCRIPTION
If log-file is set, log-file-level will have a reasonable default now, instead of being empty (i.e no logging)