### PR TITLE
Changed approximate time for locked_transfer command

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -4508,7 +4508,7 @@ bool simple_wallet::transfer_main(int transfer_type, const std::vector<std::stri
 		}
 		if(locked_blocks > 1000000)
 		{
-			GULPS_PRINT_FAIL(tr("Locked blocks too high, max 1000000 (˜4 yrs)"));
+			GULPS_PRINT_FAIL(tr("Locked blocks too high, max 1000000 (˜8 yrs)"));
 			return true;
 		}
 		local_args.pop_back();


### PR DESCRIPTION
Hey,

Locked blocks transfer for 1000000 blocks is approximate 8 years (~8 yrs). So `if (locked_transfer > 1000000)` the `GULPS_PRINT_FAIL` message should be `"Locked blocks too high, max 1000000 (˜8 yrs)"`.

If this is okay let me know, I can also change the number in the other files. If the 4 years is meant to stay and not change, then the if statement should change to:

```
if(locked_blocks > 500000)
		{
			GULPS_PRINT_FAIL(tr("Locked blocks too high, max 500000 (˜4 yrs)"));
			return true;
		}
```

P.S. I'm not sure if this is the way of submitting a PR to Ryo's codebase. Created a brand new branch with the specific name to what is being suggested. If something needs to be changed let me know. 

Thank you

:)