### PR TITLE
Resolve nuisance errors

### DIFF
--- a/contrib/epee/include/net/levin_protocol_handler_async.h
+++ b/contrib/epee/include/net/levin_protocol_handler_async.h
@@ -298,7 +298,7 @@ class async_protocol_handler
 		GULPS_LOG_L2(m_connection_context, "[levin_protocol] -->> start_outer_call");
 		if(!m_pservice_endpoint->add_ref())
 		{
-			GULPS_ERROR(m_connection_context , " [levin_protocol] -->> start_outer_call failed");
+			GULPS_LOG_L1(m_connection_context , " [levin_protocol] -->> start_outer_call failed");
 			return false;
 		}
 		boost::interprocess::ipcdetail::atomic_inc32(&m_wait_count);

--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -3370,7 +3370,9 @@ uint8_t BlockchainLMDB::get_hard_fork_version(uint64_t height) const
 	MDB_val_copy<uint64_t> val_key(height);
 	MDB_val val_ret;
 	auto result = mdb_cursor_get(m_cur_hf_versions, &val_key, &val_ret, MDB_SET);
-	if(result == MDB_NOTFOUND || result)
+	if(result == MDB_NOTFOUND)
+		throw1(DB_ERROR(lmdb_error("Error attempting to retrieve a hard fork version at height " + boost::lexical_cast<std::string>(height) + " from the db: ", result).c_str()));
+	if(result)
 		throw0(DB_ERROR(lmdb_error("Error attempting to retrieve a hard fork version at height " + boost::lexical_cast<std::string>(height) + " from the db: ", result).c_str()));
 
 	uint8_t ret = *(const uint8_t *)val_ret.mv_data;


### PR DESCRIPTION
Resolves #265

- MDB_NOTFOUND for when the blockchain db isn't found updated to log level 1
- levin_protocol start_outer_call failed also updated to log level 1