### PR TITLE
Fix build errors on Windows, Mac, and Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -891,6 +891,22 @@ if(USE_READLINE)
     include_directories(${Readline_INCLUDE_DIR})
     message(STATUS "Found readline library at: ${Readline_ROOT_DIR}")
     set(EPEE_READLINE epee_readline)
+  elseif (NOT READLINE_FOUND AND MINGW)
+    # Due to a problem in the package searching process for MinGW, some include paths
+    # are not found but library paths are.
+    if (BUILD_64)
+      set(Readline_ROOT_DIR /mingw64)
+    else()
+      set(Readline_ROOT_DIR /mingw32)
+    endif()
+    set(Readline_INCLUDE_DIR ${Readline_ROOT_DIR}/include)
+    message(WARNING "Readline was not found by automatic MinGW search so using default root directory: ${Readline_ROOT_DIR} and include directory ${Readline_INCLUDE_DIR}")
+  elseif (Readline_LIBRARY AND NOT READLINE_FOUND AND APPLE)
+    # On Mac OS, readline headers installed with Homebrew is sometimes not detected.
+    # But since it could legitimately be not present, guard it with the library needing to be found
+    set(Readline_ROOT_DIR /usr/local)
+    set(Readline_INCLUDE_DIR ${Readline_ROOT_DIR}/include)
+    message(WARNING "Readline was not found by automatic Mac OS search so using default root directory: ${Readline_ROOT_DIR} and include directory ${Readline_INCLUDE_DIR}")
   else()
     message(STATUS "Could not find GNU readline library so building without readline support")
   endif()

--- a/contrib/epee/include/console_handler.h
+++ b/contrib/epee/include/console_handler.h
@@ -46,6 +46,12 @@
 #include "readline_buffer.h"
 #endif
 
+#include <boost/bind/placeholders.hpp>
+
+using boost::placeholders::_1;
+using boost::placeholders::_2;
+
+
 namespace epee
 {
 class async_stdin_reader

--- a/contrib/epee/include/net/abstract_tcp_server2.inl
+++ b/contrib/epee/include/net/abstract_tcp_server2.inl
@@ -54,7 +54,10 @@
 
 #include "common/gulps.hpp"
 
+#include <boost/bind/placeholders.hpp>
 
+using boost::placeholders::_1;
+using boost::placeholders::_2;
 
 #define DEFAULT_TIMEOUT_MS_LOCAL boost::posix_time::milliseconds(120000) // 2 minutes
 #define DEFAULT_TIMEOUT_MS_REMOTE boost::posix_time::milliseconds(10000) // 10 seconds

--- a/contrib/epee/include/storages/levin_abstract_invoke2.h
+++ b/contrib/epee/include/storages/levin_abstract_invoke2.h
@@ -32,7 +32,12 @@
 
 #include "common/gulps.hpp"
 
+#include <boost/bind/placeholders.hpp>
 
+using boost::placeholders::_1;
+using boost::placeholders::_2;
+using boost::placeholders::_3;
+using boost::placeholders::_4;
 
 namespace epee
 {

--- a/external/unbound/CMakeLists.txt
+++ b/external/unbound/CMakeLists.txt
@@ -225,8 +225,10 @@ endif ()
 if (MINGW)
   # There is no variable for this (probably due to the fact that the pthread
   # library is implicit with a link in msys).
+  set(CMAKE_FIND_LIBRARY_SUFFIXES .dll ${CMAKE_FIND_LIBRARY_SUFFIXES})
   find_library(win32pthread
-    NAMES libwinpthread-1.dll)
+    NAMES winpthread-1 libwinpthread-1.dll
+    HINTS "C:\\msys64\\mingw64\\bin")
   foreach (input IN LISTS win32pthread OPENSSL_LIBRARIES)
     # Copy shared libraries into the build tree so that no PATH manipulation is
     # necessary.

--- a/src/checkpoints/checkpoints.h
+++ b/src/checkpoints/checkpoints.h
@@ -51,6 +51,11 @@
 #include <map>
 #include <vector>
 
+#include <boost/bind/placeholders.hpp>
+
+using boost::placeholders::_1;
+using boost::placeholders::_2;
+
 #define ADD_CHECKPOINT(h, hash) GULPS_CHECK_AND_ASSERT(add_checkpoint(h, hash), false);
 #define JSON_HASH_FILE_NAME "checkpoints.json"
 

--- a/src/common/gulps.hpp
+++ b/src/common/gulps.hpp
@@ -57,6 +57,7 @@
 #include "string.hpp"
 #include <fmt/format.h>
 #include <fmt/time.h>
+#include <boost/mpl/contains.hpp>
 #include <boost/algorithm/string.hpp>
 #include "../cryptonote_config.h"
 

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -2277,6 +2277,10 @@ bool Blockchain::get_transactions_blobs(const t_ids_container &txs_ids, t_tx_con
 	}
 	return true;
 }
+
+template bool Blockchain::get_transactions_blobs<std::vector<crypto::hash>, std::list<cryptonote::blobdata>, std::list<crypto::hash>>(const std::vector<crypto::hash>&, std::list<cryptonote::blobdata>&, std::list<crypto::hash>&) const;
+template bool Blockchain::get_transactions_blobs<std::list<crypto::hash>, std::list<cryptonote::blobdata>, std::list<crypto::hash>>(const std::list<crypto::hash>&, std::list<cryptonote::blobdata>&, std::list<crypto::hash>&) const;
+ 
 //------------------------------------------------------------------
 template <class t_ids_container, class t_tx_container, class t_missed_container>
 bool Blockchain::get_transactions(const t_ids_container &txs_ids, t_tx_container &txs, t_missed_container &missed_txs) const

--- a/tests/core_tests/chaingen.h
+++ b/tests/core_tests/chaingen.h
@@ -53,6 +53,11 @@
 #include "misc_language.h"
 #include "common/gulps.hpp"
 
+#include <boost/bind/placeholders.hpp>
+using boost::placeholders::_1;
+using boost::placeholders::_2;
+using boost::placeholders::_3;
+
 struct callback_entry
 {
 	std::string callback_name;


### PR DESCRIPTION
This set of commits fixes a series of compilation and CMake errors on all platforms, seen when building ryo-currency.