### PR TITLE
fix: remove loud error on docker

### DIFF
--- a/contrib/epee/include/net/http_client.h
+++ b/contrib/epee/include/net/http_client.h
@@ -369,10 +369,18 @@ class http_simple_client_template : public i_target_handler
 			//--
 
 			bool res = m_net_client.send(req_buff, timeout);
-			GULPS_CHECK_AND_ASSERT_MES(res, false, "HTTP_CLIENT: Failed to SEND");
+			if(!res)
+			{
+				GULPSF_LOG_L1("HTTP_CLIENT: Failed to SEND");
+				return false;
+			}
 			if(body.size())
 				res = m_net_client.send(body, timeout);
-			GULPS_CHECK_AND_ASSERT_MES(res, false, "HTTP_CLIENT: Failed to SEND");
+			if(!res)
+			{
+				GULPSF_LOG_L1("HTTP_CLIENT: Failed to SEND");
+				return false;
+			}
 
 			m_response_info.clear();
 			m_state = reciev_machine_state_header;

--- a/src/wallet/wallet2_tx_scan.cpp
+++ b/src/wallet/wallet2_tx_scan.cpp
@@ -54,7 +54,12 @@ std::unique_ptr<wallet2::wallet_rpc_scan_data> wallet2::pull_blocks(uint64_t sta
 	req.prune = true;
 	req.start_height = start_height;
 	m_daemon_rpc_mutex.lock();
-	bool r = epee::net_utils::invoke_http_bin("/getblocks.bin", req, res, m_http_client, rpc_timeout);
+	bool r = false;
+	for(size_t i=0; i <= 3 && r != true; i++)
+	{
+		GULPSF_LOG_L1("invoke_http_bin attempt {}", i);
+		r = epee::net_utils::invoke_http_bin("/getblocks.bin", req, res, m_http_client, rpc_timeout);
+	}
 	m_daemon_rpc_mutex.unlock();
 	THROW_WALLET_EXCEPTION_IF(!r, error::no_connection_to_daemon, "getblocks.bin");
 	THROW_WALLET_EXCEPTION_IF(res.status == CORE_RPC_STATUS_BUSY, error::daemon_busy, "getblocks.bin");


### PR DESCRIPTION
Docker tends to drop connections after 10 seconds. Therefore we were complaining loudly that a connection was dropped before retrying (everything worked, therefore this change is only log-cosmetic).