### PR TITLE
fix: remove depreciated lang features

### DIFF
--- a/contrib/epee/include/misc_language.h
+++ b/contrib/epee/include/misc_language.h
@@ -81,16 +81,6 @@ t_iterator move_it_backward(t_iterator it, size_t count)
 
 // TEMPLATE STRUCT less
 template <class _Ty>
-struct less_as_pod
-	: public std::binary_function<_Ty, _Ty, bool>
-{ // functor for operator<
-	bool operator()(const _Ty &_Left, const _Ty &_Right) const
-	{ // apply operator< to operands
-		return memcmp(&_Left, &_Right, sizeof(_Left)) < 0;
-	}
-};
-
-template <class _Ty>
 bool is_less_as_pod(const _Ty &_Left, const _Ty &_Right)
 { // apply operator< to operands
 	return memcmp(&_Left, &_Right, sizeof(_Left)) < 0;

--- a/src/cryptonote_basic/cryptonote_basic_impl.h
+++ b/src/cryptonote_basic/cryptonote_basic_impl.h
@@ -55,14 +55,6 @@ namespace cryptonote
 /************************************************************************/
 /*                                                                      */
 /************************************************************************/
-template <class t_array>
-struct array_hasher : std::unary_function<t_array &, std::size_t>
-{
-	std::size_t operator()(const t_array &val) const
-	{
-		return boost::hash_range(&val.data[0], &val.data[sizeof(val.data)]);
-	}
-};
 
 #pragma pack(push, 1)
 struct public_address_outer_blob


### PR DESCRIPTION
- std::binary_function
- std::unary_function

We aren't using them so no replacement required