### PR TITLE
RCT verification and block span fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 /build
+/debug-artifacts/
 /tags
 log/
 test-wallets/

--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,6 @@ local.properties
 
 # Document
 doc
+.clang-format
+
+.editorconfig

--- a/src/crypto/crypto-ops.c
+++ b/src/crypto/crypto-ops.c
@@ -4773,14 +4773,50 @@ int sc_isnonzero(const unsigned char *s)
 
 int ge_p3_is_point_at_infinity(const ge_p3 *p)
 {
-	// X = 0 and Y == Z
-	int n;
-	for (n = 0; n < 10; ++n)
-	{
-		if (p->X[n] | p->T[n])
-			return 0;
-		if (p->Y[n] != p->Z[n])
-		return 0;
-	}
-	return 1;
+// https://eprint.iacr.org/2008/522
+  // X == T == 0 and Y/Z == 1
+  // note: convert all pieces to canonical bytes in case rounding is required (i.e. an element is > q)
+  // note2: even though T = XY/Z is true for valid point representations (implying it isn't necessary to
+  //        test T == 0), the input to this function might NOT be valid, so we must test T == 0
+  char result_X_bytes[32];
+  fe_tobytes((unsigned char*)&result_X_bytes, p->X);
+
+  // X != 0
+  for (int i = 0; i < 32; ++i)
+  {
+    if (result_X_bytes[i])
+      return 0;
+  }
+
+  char result_T_bytes[32];
+  fe_tobytes((unsigned char*)&result_T_bytes, p->T);
+
+  // T != 0
+  for (int i = 0; i < 32; ++i)
+  {
+    if (result_T_bytes[i])
+      return 0;
+  }
+
+  char result_Y_bytes[32];
+  char result_Z_bytes[32];
+  fe_tobytes((unsigned char*)&result_Y_bytes, p->Y);
+  fe_tobytes((unsigned char*)&result_Z_bytes, p->Z);
+
+  // Y != Z
+  for (int i = 0; i < 32; ++i)
+  {
+    if (result_Y_bytes[i] != result_Z_bytes[i])
+      return 0;
+  }
+
+  // is Y nonzero? then Y/Z == 1
+  for (int i = 0; i < 32; ++i)
+  {
+    if (result_Y_bytes[i] != 0)
+      return 1;
+  }
+
+  // Y/Z = 0/0
+  return 0;
 }

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -3494,6 +3494,21 @@ bool Blockchain::flush_txes_from_pool(const std::list<crypto::hash> &txids)
 	}
 	return res;
 }
+
+/**
+ * Sets m_last_block_add_tick
+ */
+void Blockchain::set_last_block_add_tick()
+{
+	m_last_block_add_tick.store(epee::misc_utils::get_tick_count());
+}
+/**
+ * Gets m_last_block_add_tick
+ */
+uint64_t Blockchain::get_last_block_add_tick() const
+{
+	return m_last_block_add_tick.load();
+}
 //------------------------------------------------------------------
 //      Needs to validate the block and acquire each transaction from the
 //      transaction mem_pool, then pass the block and transactions to
@@ -3854,6 +3869,7 @@ bool Blockchain::handle_block_to_main_chain(const block &bl, const crypto::hash 
 	}
 
 	bvc.m_added_to_main_chain = true;
+	set_last_block_add_tick();
 	++m_sync_counter;
 
 	// appears to be a NOP *and* is called elsewhere.  wat?

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -935,7 +935,12 @@ class Blockchain
      * @param map return-by-reference the hashes for each block
      */
 	void block_longhash_worker(cn_pow_hash_v2 &hash_ctx, const std::vector<block> &blocks, std::unordered_map<crypto::hash, crypto::hash> &map);
-
+	/**
+     * @brief gets the local tick count when the last block was added
+     *
+     * @return tick count from when the last block was accepted to the main chain
+     */
+	uint64_t get_last_block_add_tick() const;
 	/**
      * @brief returns a set of known alternate chains
      *
@@ -1034,6 +1039,11 @@ class Blockchain
 
 	cn_pow_hash_v2 m_pow_ctx;
 	std::vector<cn_pow_hash_v2> m_hash_ctxes_multi;
+
+	// Local tick count from when the last block was accepted to the main chain.
+	std::atomic<uint64_t> m_last_block_add_tick{0};
+	// Updates the last block add tick to the current local tick count.
+	void set_last_block_add_tick();
 
 	checkpoints m_checkpoints;
 	bool m_enforce_dns_checkpoints;

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -283,6 +283,11 @@ uint64_t core::get_current_blockchain_height() const
 {
 	return m_blockchain_storage.get_current_blockchain_height();
 }
+
+uint64_t core::get_last_block_add_tick() const
+{
+	return m_blockchain_storage.get_last_block_add_tick();
+}
 //-----------------------------------------------------------------------------------------------
 void core::get_blockchain_top(uint64_t &height, crypto::hash &top_id) const
 {

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -316,6 +316,12 @@ class core : public i_miner_handler
 	uint64_t get_current_blockchain_height() const;
 
 	/**
+      * @copydoc Blockchain::get_last_block_add_tick
+      *
+      * @note see Blockchain::get_last_block_add_tick()
+      */
+	uint64_t get_last_block_add_tick() const;
+	/**
       * @brief get the hash and height of the most recent block
       *
       * @param height return-by-reference height of the block

--- a/src/cryptonote_protocol/block_queue.cpp
+++ b/src/cryptonote_protocol/block_queue.cpp
@@ -147,13 +147,16 @@ void block_queue::remove_spans(const boost::uuids::uuid &connection_id, uint64_t
 	}
 }
 
+// Removes queued non-placeholder spans from the given height onward and returns how many were dropped.
 size_t block_queue::remove_spans_starting_at(uint64_t start_block_height)
 {
 	boost::unique_lock<boost::recursive_mutex> lock(mutex);
+	// Count removed spans so callers can report how much stale queued work was discarded.
 	size_t removed = 0;
 	for(block_map::iterator i = blocks.begin(); i != blocks.end();)
 	{
 		block_map::iterator j = i++;
+		// Preserve blockchain placeholders while removing peer-supplied spans past the reset point.
 		if(!is_blockchain_placeholder(*j) && j->start_block_height >= start_block_height)
 		{
 			blocks.erase(j);

--- a/src/cryptonote_protocol/block_queue.cpp
+++ b/src/cryptonote_protocol/block_queue.cpp
@@ -147,6 +147,22 @@ void block_queue::remove_spans(const boost::uuids::uuid &connection_id, uint64_t
 	}
 }
 
+size_t block_queue::remove_spans_starting_at(uint64_t start_block_height)
+{
+	boost::unique_lock<boost::recursive_mutex> lock(mutex);
+	size_t removed = 0;
+	for(block_map::iterator i = blocks.begin(); i != blocks.end();)
+	{
+		block_map::iterator j = i++;
+		if(!is_blockchain_placeholder(*j) && j->start_block_height >= start_block_height)
+		{
+			blocks.erase(j);
+			++removed;
+		}
+	}
+	return removed;
+}
+
 uint64_t block_queue::get_max_block_height() const
 {
 	boost::unique_lock<boost::recursive_mutex> lock(mutex);

--- a/src/cryptonote_protocol/block_queue.h
+++ b/src/cryptonote_protocol/block_queue.h
@@ -87,6 +87,7 @@ class block_queue
 	void flush_stale_spans(const std::set<boost::uuids::uuid> &live_connections);
 	bool remove_span(uint64_t start_block_height, std::list<crypto::hash> *hashes = NULL);
 	void remove_spans(const boost::uuids::uuid &connection_id, uint64_t start_block_height);
+	// Drops queued peer spans at or after a height so sync can restart from a known anchor.
 	size_t remove_spans_starting_at(uint64_t start_block_height);
 	uint64_t get_max_block_height() const;
 	void print() const;

--- a/src/cryptonote_protocol/block_queue.h
+++ b/src/cryptonote_protocol/block_queue.h
@@ -87,6 +87,7 @@ class block_queue
 	void flush_stale_spans(const std::set<boost::uuids::uuid> &live_connections);
 	bool remove_span(uint64_t start_block_height, std::list<crypto::hash> *hashes = NULL);
 	void remove_spans(const boost::uuids::uuid &connection_id, uint64_t start_block_height);
+	size_t remove_spans_starting_at(uint64_t start_block_height);
 	uint64_t get_max_block_height() const;
 	void print() const;
 	std::string get_overview() const;

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.h
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.h
@@ -125,6 +125,8 @@ class t_cryptonote_protocol_handler : public i_cryptonote_protocol, cryptonote_p
 	bool on_callback(cryptonote_connection_context &context);
 	t_core &get_core() { return m_core; }
 	bool is_synchronized() { return m_synchronized; }
+	// Returns true when the core accepted a block within the recent-block window.
+	bool was_block_added_recently() const;
 	void log_connections();
 	std::list<connection_info> get_connections();
 	const block_queue &get_block_queue() const { return m_block_queue; }

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -1573,8 +1573,8 @@ bool t_cryptonote_protocol_handler<t_core>::was_block_added_recently() const
 {
 	// 10 minutes in milliseconds
 	constexpr uint64_t max_wait = 10*60*1000;
-	const uint64_t last = m_core.get_last_block_add_tick();
-	return last && epee::misc_utils::get_tick_count() - last <= max_wait;
+	const uint64_t last_block = m_core.get_last_block_add_tick();
+	return last_block && epee::misc_utils::get_tick_count() - last_block <= max_wait;
 }
 //------------------------------------------------------------------------------------------------------------------------
 template <class t_core>

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -1569,6 +1569,15 @@ bool t_cryptonote_protocol_handler<t_core>::on_connection_synchronized()
 }
 //------------------------------------------------------------------------------------------------------------------------
 template <class t_core>
+bool t_cryptonote_protocol_handler<t_core>::was_block_added_recently() const
+{
+	// 10 minutes in milliseconds
+	constexpr uint64_t max_wait = 10*60*1000;
+	const uint64_t last = m_core.get_last_block_add_tick();
+	return last && epee::misc_utils::get_tick_count() - last <= max_wait;
+}
+//------------------------------------------------------------------------------------------------------------------------
+template <class t_core>
 size_t t_cryptonote_protocol_handler<t_core>::get_synchronizing_connections_count()
 {
 	size_t count = 0;

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -1020,7 +1020,7 @@ int t_cryptonote_protocol_handler<t_core>::try_add_next_blocks(cryptonote_connec
 						// Clear per-peer request state so the next request starts from the refreshed queue anchor.
 						context.m_needed_objects.clear();
 						context.m_requested_objects.clear();
-						context.m_last_response_height = 0;
+						context.m_last_response_height = flush_from_height > 0 ? flush_from_height - 1 : 0;
 						context.m_last_known_hash = crypto::null_hash;
 						goto skip;
 					}

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -1008,10 +1008,16 @@ int t_cryptonote_protocol_handler<t_core>::try_add_next_blocks(cryptonote_connec
 					{
 						// this can happen if a connection was sicced onto a late span, if it did not have those blocks,
 						// since we don't know that at the sic time
-						GULPS_ERROR( context_str, " Got block with unknown parent which was not requested - querying block hashes");
-						m_block_queue.remove_spans(span_connection_id, start_height);
+						const uint64_t local_height = m_core.get_current_blockchain_height();
+						const uint64_t flush_from_height = start_height < local_height ? start_height : local_height;
+						const size_t removed_spans = m_block_queue.remove_spans_starting_at(flush_from_height);
+						GULPS_ERROR( context_str, " Got block with unknown parent which was not requested - re-anchoring sync at local height");
+						GULPSF_LOG_L1("{} removed {} queued spans from height {} after disconnected span {}-{}",
+							context_str, removed_spans, flush_from_height, start_height, start_height + blocks.size() - 1);
 						context.m_needed_objects.clear();
+						context.m_requested_objects.clear();
 						context.m_last_response_height = 0;
+						context.m_last_known_hash = crypto::null_hash;
 						goto skip;
 					}
 

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -1008,12 +1008,16 @@ int t_cryptonote_protocol_handler<t_core>::try_add_next_blocks(cryptonote_connec
 					{
 						// this can happen if a connection was sicced onto a late span, if it did not have those blocks,
 						// since we don't know that at the sic time
+						// Reset queued work from the lower of the bad span and local chain height to re-anchor sync safely.
 						const uint64_t local_height = m_core.get_current_blockchain_height();
 						const uint64_t flush_from_height = start_height < local_height ? start_height : local_height;
+						// Track how many queued spans were discarded so the re-anchor action is visible in logs.
 						const size_t removed_spans = m_block_queue.remove_spans_starting_at(flush_from_height);
+						// Report the disconnected span and the queue cleanup that follows it.
 						GULPS_ERROR( context_str, " Got block with unknown parent which was not requested - re-anchoring sync at local height");
 						GULPSF_LOG_L1("{} removed {} queued spans from height {} after disconnected span {}-{}",
 							context_str, removed_spans, flush_from_height, start_height, start_height + blocks.size() - 1);
+						// Clear per-peer request state so the next request starts from the refreshed queue anchor.
 						context.m_needed_objects.clear();
 						context.m_requested_objects.clear();
 						context.m_last_response_height = 0;

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -1060,8 +1060,11 @@ int t_cryptonote_protocol_handler<t_core>::try_add_next_blocks(cryptonote_connec
 					{
 						if(tvc[i].m_verifivation_failed)
 						{
-							if(!m_p2p->for_connection(span_connection_id, [&](cryptonote_connection_context &context, nodetool::peerid_type peer_id, uint32_t f) -> bool {
-								   GULPSF_LOG_ERROR("{} transaction verification failed on NOTIFY_RESPONSE_GET_OBJECTS, tx_id = {}, dropping connection", context_str, epee::string_tools::pod_to_hex(get_blob_hash(*it)) );
+							if(!m_p2p->for_connection(span_connection_id, [&](cryptonote_connection_context &context, nodetool::peerid_type peer_id, uint32_t flag) -> bool {
+									   transaction tx;
+									   if(!parse_and_validate_tx_from_blob(*it, tx))
+										   tx = transaction();
+								   GULPSF_LOG_ERROR("{} transaction verification failed on NOTIFY_RESPONSE_GET_OBJECTS, tx_id = {}, dropping connection", context_str, epee::string_tools::pod_to_hex(get_transaction_hash(tx)) );
 								   drop_connection(context, false, true);
 								   return 1;
 							   }))

--- a/src/p2p/net_node.h
+++ b/src/p2p/net_node.h
@@ -250,6 +250,10 @@ class node_server : public epee::levin::levin_commands_handler<p2p_connection_co
 	size_t get_random_index_with_fixed_probability(size_t max_index);
 	bool is_peer_used(const peerlist_entry &peer);
 	bool is_peer_used(const anchor_peerlist_entry &peer);
+	// Returns true when at least one peer has completed the p2p handshake.
+	bool has_handshaked_peer();
+	// Mutes seed warnings when the daemon already has useful peer/sync state.
+	bool should_mute_seed_warnings();
 	bool is_addr_connected(const epee::net_utils::network_address &peer);
 	void add_upnp_port_mapping(uint32_t port);
 	void delete_upnp_port_mapping(uint32_t port);

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -1158,7 +1158,7 @@ bool node_server<t_payload_net_handler>::connect_to_seed()
 		{
 			if(!fallback_nodes_added)
 			{
-				constexpr char *try_fall_seeds = "Failed to connect to any of seed peers, trying fallback seeds";
+				constexpr const char *try_fall_seeds = "Failed to connect to any of seed peers, trying fallback seeds";
 				if(!should_mute_seed_warnings())
 				{
 					GULPS_WARN(try_fall_seeds);
@@ -1178,7 +1178,7 @@ bool node_server<t_payload_net_handler>::connect_to_seed()
 			}
 			else
 			{
-				constexpr char *con_without_seeds = "Failed to connect to any of seed peers, continuing without seeds";
+				constexpr const char *con_without_seeds = "Failed to connect to any of seed peers, continuing without seeds";
 				if(!should_mute_seed_warnings())
 				{
 					GULPS_WARN(con_without_seeds);

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -1154,7 +1154,6 @@ bool node_server<t_payload_net_handler>::connect_to_seed()
 		if(try_to_connect_and_handshake_with_new_peer(m_seed_nodes[current_index], true))
 			break;
 		if(++try_count > m_seed_nodes.size())
-
 		{
 			if(!fallback_nodes_added)
 			{

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -1154,44 +1154,43 @@ bool node_server<t_payload_net_handler>::connect_to_seed()
 		if(try_to_connect_and_handshake_with_new_peer(m_seed_nodes[current_index], true))
 			break;
 		if(++try_count > m_seed_nodes.size())
-				
+
+		{
+			if(!fallback_nodes_added)
 			{
-				if(!fallback_nodes_added)
-					{
-						const char *try_fall_seeds = "Failed to connect to any of seed peers, trying fallback seeds";
-						if(!should_mute_seed_warnings())
-						{
-							GULPS_WARN(try_fall_seeds);
-						}
-						else
-						{
-							GULPS_LOG_L1(try_fall_seeds);
-						}
-						
-						for(const auto &peer : get_seed_nodes(m_nettype))
-						{
-							GULPSF_LOG_L1("Fallback seed node: {}", peer);
-							append_net_address(m_seed_nodes, peer);
-						}
-						fallback_nodes_added = true;
-						// continue for another few cycles
-					}
-					else
-					{
-						const char *con_without_seeds = "Failed to connect to any of seed peers, continuing without seeds";
-						if(!should_mute_seed_warnings())
-						{
-							GULPS_WARN(con_without_seeds);
-						}
-						else
-						{
-							GULPS_LOG_L1(con_without_seeds);
-						}
-						
-						break;
-						
-					}
+				constexpr char *try_fall_seeds = "Failed to connect to any of seed peers, trying fallback seeds";
+				if(!should_mute_seed_warnings())
+				{
+					GULPS_WARN(try_fall_seeds);
+				}
+				else
+				{
+					GULPS_LOG_L1(try_fall_seeds);
+				}
+
+				for(const auto &peer : get_seed_nodes(m_nettype))
+				{
+					GULPSF_LOG_L1("Fallback seed node: {}", peer);
+					append_net_address(m_seed_nodes, peer);
+				}
+				fallback_nodes_added = true;
+				// continue for another few cycles
 			}
+			else
+			{
+				constexpr char *con_without_seeds = "Failed to connect to any of seed peers, continuing without seeds";
+				if(!should_mute_seed_warnings())
+				{
+					GULPS_WARN(con_without_seeds);
+				}
+				else
+				{
+					GULPS_LOG_L1(con_without_seeds);
+				}
+
+				break;
+			}
+		}
 		if(++current_index >= m_seed_nodes.size())
 			current_index = 0;
 	}

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -986,7 +986,6 @@ bool node_server<t_payload_net_handler>::check_connection_and_handshake_with_pee
 }
 
 #undef priority_str
-
 //-----------------------------------------------------------------------------------
 template <class t_payload_net_handler>
 bool node_server<t_payload_net_handler>::is_addr_recently_failed(const epee::net_utils::network_address &addr)
@@ -1000,6 +999,27 @@ bool node_server<t_payload_net_handler>::is_addr_recently_failed(const epee::net
 		return false;
 	else
 		return true;
+}
+//-----------------------------------------------------------------------------------
+template<class t_payload_net_handler>
+bool node_server<t_payload_net_handler>::has_handshaked_peer()
+{
+	bool connected = false;
+	m_net_server.get_config_object().foreach_connection([&](const p2p_connection_context &cntxt) {
+    if(cntxt.peer_id)
+    {
+      connected = true;
+      return false;
+    }
+    return true;
+  });
+  return connected;
+}
+//-----------------------------------------------------------------------------------
+template <class t_payload_net_handler>
+bool node_server<t_payload_net_handler>::should_mute_seed_warnings() 
+{
+	return has_handshaked_peer() && (m_payload_handler.is_synchronized() || m_payload_handler.was_block_added_recently());
 }
 //-----------------------------------------------------------------------------------
 template <class t_payload_net_handler>
@@ -1115,6 +1135,7 @@ bool node_server<t_payload_net_handler>::make_new_connection_from_peerlist(bool 
 	}
 	return false;
 }
+
 //-----------------------------------------------------------------------------------
 template <class t_payload_net_handler>
 bool node_server<t_payload_net_handler>::connect_to_seed()
@@ -1133,24 +1154,44 @@ bool node_server<t_payload_net_handler>::connect_to_seed()
 		if(try_to_connect_and_handshake_with_new_peer(m_seed_nodes[current_index], true))
 			break;
 		if(++try_count > m_seed_nodes.size())
-		{
-			if(!fallback_nodes_added)
+				
 			{
-				GULPS_WARN("Failed to connect to any of seed peers, trying fallback seeds");
-				for(const auto &peer : get_seed_nodes(m_nettype))
-				{
-					GULPSF_LOG_L1("Fallback seed node: {}", peer);
-					append_net_address(m_seed_nodes, peer);
-				}
-				fallback_nodes_added = true;
-				// continue for another few cycles
+				if(!fallback_nodes_added)
+					{
+						const char *try_fall_seeds = "Failed to connect to any of seed peers, trying fallback seeds";
+						if(!should_mute_seed_warnings())
+						{
+							GULPS_WARN(try_fall_seeds);
+						}
+						else
+						{
+							GULPS_LOG_L1(try_fall_seeds);
+						}
+						
+						for(const auto &peer : get_seed_nodes(m_nettype))
+						{
+							GULPSF_LOG_L1("Fallback seed node: {}", peer);
+							append_net_address(m_seed_nodes, peer);
+						}
+						fallback_nodes_added = true;
+						// continue for another few cycles
+					}
+					else
+					{
+						const char *con_without_seeds = "Failed to connect to any of seed peers, continuing without seeds";
+						if(!should_mute_seed_warnings())
+						{
+							GULPS_WARN(con_without_seeds);
+						}
+						else
+						{
+							GULPS_LOG_L1(con_without_seeds);
+						}
+						
+						break;
+						
+					}
 			}
-			else
-			{
-				GULPS_WARN("Failed to connect to any of seed peers, continuing without seeds");
-				break;
-			}
-		}
 		if(++current_index >= m_seed_nodes.size())
 			current_index = 0;
 	}

--- a/tests/core_proxy/core_proxy.h
+++ b/tests/core_proxy/core_proxy.h
@@ -68,6 +68,8 @@ class proxy_core
 	void on_synchronized() {}
 	void safesyncmode(const bool) {}
 	uint64_t get_current_blockchain_height() { return 1; }
+	// Protocol handler core shim; these tests do not simulate recent block adds.
+	uint64_t get_last_block_add_tick() const { return 0; }
 	void set_target_blockchain_height(uint64_t) {}
 	bool init(const boost::program_options::variables_map &vm);
 	bool deinit() { return true; }

--- a/tests/unit_tests/ban.cpp
+++ b/tests/unit_tests/ban.cpp
@@ -53,6 +53,8 @@ class test_core
 	void on_synchronized() {}
 	void safesyncmode(const bool) {}
 	uint64_t get_current_blockchain_height() const { return 1; }
+	// Protocol handler core shim; these tests do not simulate recent block adds.
+	uint64_t get_last_block_add_tick() const { return 0; }
 	void set_target_blockchain_height(uint64_t) {}
 	bool init(const boost::program_options::variables_map &vm) { return true; }
 	bool deinit() { return true; }


### PR DESCRIPTION
## Summary

Fixes a long-sync issue where valid Bulletproof/RCT transactions could be falsely rejected with `Verification failure at step 1`.

After the false rejection, the tx hash was inserted into `bad_semantics_txes`. Later peers serving the same valid transaction were then rejected immediately by the bad-semantics precheck, causing repeated `transaction verification failed on NOTIFY_RESPONSE_GET_OBJECTS` disconnect loops.

This PR also improves sync recovery when queued spans become disconnected from the local chain by adding `remove_spans_starting_at()` and using it to clear stale queued spans after an unknown-parent condition.

## Root Cause

`ge_p3_is_point_at_infinity()` previously checked projective identity using raw limb array equality. During Bulletproof verification, a valid identity point can have non-canonical internal field representations where `Y` and `Z` differ as raw arrays but are equal as field values modulo `2^255 - 19`.

That caused a mathematically valid identity point to be treated as non-identity, falsely failing RCT verification.

Separately, after a failed or disconnected span, later queued spans could still depend on a missing parent block. This caused repeated `Got block with unknown parent which was not requested` errors during sync.

## Changes

- Update `ge_p3_is_point_at_infinity()` to check field-element equality instead of raw limb equality.
- Add `remove_spans_starting_at()` for block queue cleanup.
- Use the new span cleanup path when sync encounters an unknown parent that was not requested.

## Validation

For the RCT failure, forcing `ge_p3_is_point_at_infinity()` to return failure reproduced the repeated bad-semantics disconnect loop. After updating the function to compare canonical field values, the daemon was able to continue long-running sync without hitting the former `Verification failure at step 1` loop.

For the unknown-parent path, the daemon now clears stale queued spans from the affected height and re-anchors sync instead of repeatedly processing disconnected spans.