### PR TITLE
Pr freeze fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 /build
+/debug-artifacts/
 /tags
 log/
 test-wallets/

--- a/src/crypto/crypto-ops.c
+++ b/src/crypto/crypto-ops.c
@@ -4773,14 +4773,50 @@ int sc_isnonzero(const unsigned char *s)
 
 int ge_p3_is_point_at_infinity(const ge_p3 *p)
 {
-	// X = 0 and Y == Z
-	int n;
-	for (n = 0; n < 10; ++n)
-	{
-		if (p->X[n] | p->T[n])
-			return 0;
-		if (p->Y[n] != p->Z[n])
-		return 0;
-	}
-	return 1;
+// https://eprint.iacr.org/2008/522
+  // X == T == 0 and Y/Z == 1
+  // note: convert all pieces to canonical bytes in case rounding is required (i.e. an element is > q)
+  // note2: even though T = XY/Z is true for valid point representations (implying it isn't necessary to
+  //        test T == 0), the input to this function might NOT be valid, so we must test T == 0
+  char result_X_bytes[32];
+  fe_tobytes((unsigned char*)&result_X_bytes, p->X);
+
+  // X != 0
+  for (int i = 0; i < 32; ++i)
+  {
+    if (result_X_bytes[i])
+      return 0;
+  }
+
+  char result_T_bytes[32];
+  fe_tobytes((unsigned char*)&result_T_bytes, p->T);
+
+  // T != 0
+  for (int i = 0; i < 32; ++i)
+  {
+    if (result_T_bytes[i])
+      return 0;
+  }
+
+  char result_Y_bytes[32];
+  char result_Z_bytes[32];
+  fe_tobytes((unsigned char*)&result_Y_bytes, p->Y);
+  fe_tobytes((unsigned char*)&result_Z_bytes, p->Z);
+
+  // Y != Z
+  for (int i = 0; i < 32; ++i)
+  {
+    if (result_Y_bytes[i] != result_Z_bytes[i])
+      return 0;
+  }
+
+  // is Y nonzero? then Y/Z == 1
+  for (int i = 0; i < 32; ++i)
+  {
+    if (result_Y_bytes[i] != 0)
+      return 1;
+  }
+
+  // Y/Z = 0/0
+  return 0;
 }

--- a/src/cryptonote_protocol/block_queue.cpp
+++ b/src/cryptonote_protocol/block_queue.cpp
@@ -147,13 +147,16 @@ void block_queue::remove_spans(const boost::uuids::uuid &connection_id, uint64_t
 	}
 }
 
+// Removes queued non-placeholder spans from the given height onward and returns how many were dropped.
 size_t block_queue::remove_spans_starting_at(uint64_t start_block_height)
 {
 	boost::unique_lock<boost::recursive_mutex> lock(mutex);
+	// Count removed spans so callers can report how much stale queued work was discarded.
 	size_t removed = 0;
 	for(block_map::iterator i = blocks.begin(); i != blocks.end();)
 	{
 		block_map::iterator j = i++;
+		// Preserve blockchain placeholders while removing peer-supplied spans past the reset point.
 		if(!is_blockchain_placeholder(*j) && j->start_block_height >= start_block_height)
 		{
 			blocks.erase(j);

--- a/src/cryptonote_protocol/block_queue.cpp
+++ b/src/cryptonote_protocol/block_queue.cpp
@@ -147,6 +147,22 @@ void block_queue::remove_spans(const boost::uuids::uuid &connection_id, uint64_t
 	}
 }
 
+size_t block_queue::remove_spans_starting_at(uint64_t start_block_height)
+{
+	boost::unique_lock<boost::recursive_mutex> lock(mutex);
+	size_t removed = 0;
+	for(block_map::iterator i = blocks.begin(); i != blocks.end();)
+	{
+		block_map::iterator j = i++;
+		if(!is_blockchain_placeholder(*j) && j->start_block_height >= start_block_height)
+		{
+			blocks.erase(j);
+			++removed;
+		}
+	}
+	return removed;
+}
+
 uint64_t block_queue::get_max_block_height() const
 {
 	boost::unique_lock<boost::recursive_mutex> lock(mutex);

--- a/src/cryptonote_protocol/block_queue.h
+++ b/src/cryptonote_protocol/block_queue.h
@@ -87,6 +87,7 @@ class block_queue
 	void flush_stale_spans(const std::set<boost::uuids::uuid> &live_connections);
 	bool remove_span(uint64_t start_block_height, std::list<crypto::hash> *hashes = NULL);
 	void remove_spans(const boost::uuids::uuid &connection_id, uint64_t start_block_height);
+	// Drops queued peer spans at or after a height so sync can restart from a known anchor.
 	size_t remove_spans_starting_at(uint64_t start_block_height);
 	uint64_t get_max_block_height() const;
 	void print() const;

--- a/src/cryptonote_protocol/block_queue.h
+++ b/src/cryptonote_protocol/block_queue.h
@@ -87,6 +87,7 @@ class block_queue
 	void flush_stale_spans(const std::set<boost::uuids::uuid> &live_connections);
 	bool remove_span(uint64_t start_block_height, std::list<crypto::hash> *hashes = NULL);
 	void remove_spans(const boost::uuids::uuid &connection_id, uint64_t start_block_height);
+	size_t remove_spans_starting_at(uint64_t start_block_height);
 	uint64_t get_max_block_height() const;
 	void print() const;
 	std::string get_overview() const;

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -1020,7 +1020,7 @@ int t_cryptonote_protocol_handler<t_core>::try_add_next_blocks(cryptonote_connec
 						// Clear per-peer request state so the next request starts from the refreshed queue anchor.
 						context.m_needed_objects.clear();
 						context.m_requested_objects.clear();
-						context.m_last_response_height = 0;
+						context.m_last_response_height = flush_from_height > 0 ? flush_from_height - 1 : 0;
 						context.m_last_known_hash = crypto::null_hash;
 						goto skip;
 					}

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -1008,10 +1008,16 @@ int t_cryptonote_protocol_handler<t_core>::try_add_next_blocks(cryptonote_connec
 					{
 						// this can happen if a connection was sicced onto a late span, if it did not have those blocks,
 						// since we don't know that at the sic time
-						GULPS_ERROR( context_str, " Got block with unknown parent which was not requested - querying block hashes");
-						m_block_queue.remove_spans(span_connection_id, start_height);
+						const uint64_t local_height = m_core.get_current_blockchain_height();
+						const uint64_t flush_from_height = start_height < local_height ? start_height : local_height;
+						const size_t removed_spans = m_block_queue.remove_spans_starting_at(flush_from_height);
+						GULPS_ERROR( context_str, " Got block with unknown parent which was not requested - re-anchoring sync at local height");
+						GULPSF_LOG_L1("{} removed {} queued spans from height {} after disconnected span {}-{}",
+							context_str, removed_spans, flush_from_height, start_height, start_height + blocks.size() - 1);
 						context.m_needed_objects.clear();
+						context.m_requested_objects.clear();
 						context.m_last_response_height = 0;
+						context.m_last_known_hash = crypto::null_hash;
 						goto skip;
 					}
 

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -1008,12 +1008,16 @@ int t_cryptonote_protocol_handler<t_core>::try_add_next_blocks(cryptonote_connec
 					{
 						// this can happen if a connection was sicced onto a late span, if it did not have those blocks,
 						// since we don't know that at the sic time
+						// Reset queued work from the lower of the bad span and local chain height to re-anchor sync safely.
 						const uint64_t local_height = m_core.get_current_blockchain_height();
 						const uint64_t flush_from_height = start_height < local_height ? start_height : local_height;
+						// Track how many queued spans were discarded so the re-anchor action is visible in logs.
 						const size_t removed_spans = m_block_queue.remove_spans_starting_at(flush_from_height);
+						// Report the disconnected span and the queue cleanup that follows it.
 						GULPS_ERROR( context_str, " Got block with unknown parent which was not requested - re-anchoring sync at local height");
 						GULPSF_LOG_L1("{} removed {} queued spans from height {} after disconnected span {}-{}",
 							context_str, removed_spans, flush_from_height, start_height, start_height + blocks.size() - 1);
+						// Clear per-peer request state so the next request starts from the refreshed queue anchor.
 						context.m_needed_objects.clear();
 						context.m_requested_objects.clear();
 						context.m_last_response_height = 0;

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -1060,8 +1060,11 @@ int t_cryptonote_protocol_handler<t_core>::try_add_next_blocks(cryptonote_connec
 					{
 						if(tvc[i].m_verifivation_failed)
 						{
-							if(!m_p2p->for_connection(span_connection_id, [&](cryptonote_connection_context &context, nodetool::peerid_type peer_id, uint32_t f) -> bool {
-								   GULPSF_LOG_ERROR("{} transaction verification failed on NOTIFY_RESPONSE_GET_OBJECTS, tx_id = {}, dropping connection", context_str, epee::string_tools::pod_to_hex(get_blob_hash(*it)) );
+							if(!m_p2p->for_connection(span_connection_id, [&](cryptonote_connection_context &context, nodetool::peerid_type peer_id, uint32_t flag) -> bool {
+									   transaction tx;
+									   if(!parse_and_validate_tx_from_blob(*it, tx))
+										   tx = transaction();
+								   GULPSF_LOG_ERROR("{} transaction verification failed on NOTIFY_RESPONSE_GET_OBJECTS, tx_id = {}, dropping connection", context_str, epee::string_tools::pod_to_hex(get_transaction_hash(tx)) );
 								   drop_connection(context, false, true);
 								   return 1;
 							   }))


### PR DESCRIPTION
## Summary

Fixes a long-sync issue where valid Bulletproof/RCT transactions could be falsely rejected with `Verification failure at step 1`.

After the false rejection, the tx hash was inserted into `bad_semantics_txes`. Later peers serving the same valid transaction were then rejected immediately by the bad-semantics precheck, causing repeated `transaction verification failed on NOTIFY_RESPONSE_GET_OBJECTS` disconnect loops.

This PR also improves sync recovery when queued spans become disconnected from the local chain by adding `remove_spans_starting_at()` and using it to clear stale queued spans after an unknown-parent condition.

## Root Cause

`ge_p3_is_point_at_infinity()` previously checked projective identity using raw limb array equality. During Bulletproof verification, a valid identity point can have non-canonical internal field representations where `Y` and `Z` differ as raw arrays but are equal as field values modulo `2^255 - 19`.

That caused a mathematically valid identity point to be treated as non-identity, falsely failing RCT verification.

Separately, after a failed or disconnected span, later queued spans could still depend on a missing parent block. This caused repeated `Got block with unknown parent which was not requested` errors during sync.

## Changes

- Update `ge_p3_is_point_at_infinity()` to check field-element equality instead of raw limb equality.
- Add `remove_spans_starting_at()` for block queue cleanup.
- Use the new span cleanup path when sync encounters an unknown parent that was not requested.

## Validation

For the RCT failure, forcing `ge_p3_is_point_at_infinity()` to return failure reproduced the repeated bad-semantics disconnect loop. After updating the function to compare canonical field values, the daemon was able to continue long-running sync without hitting the former `Verification failure at step 1` loop.

For the unknown-parent path, the daemon now clears stale queued spans from the affected height and re-anchors sync instead of repeatedly processing disconnected spans.