### PR TITLE
Conditional downgrade of failure messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,6 @@ local.properties
 
 # Document
 doc
+.clang-format
+
+.editorconfig

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -3494,6 +3494,21 @@ bool Blockchain::flush_txes_from_pool(const std::list<crypto::hash> &txids)
 	}
 	return res;
 }
+
+/**
+ * Sets m_last_block_add_tick
+ */
+void Blockchain::set_last_block_add_tick()
+{
+	m_last_block_add_tick.store(epee::misc_utils::get_tick_count());
+}
+/**
+ * Gets m_last_block_add_tick
+ */
+uint64_t Blockchain::get_last_block_add_tick() const
+{
+	return m_last_block_add_tick.load();
+}
 //------------------------------------------------------------------
 //      Needs to validate the block and acquire each transaction from the
 //      transaction mem_pool, then pass the block and transactions to
@@ -3854,6 +3869,7 @@ bool Blockchain::handle_block_to_main_chain(const block &bl, const crypto::hash 
 	}
 
 	bvc.m_added_to_main_chain = true;
+	set_last_block_add_tick();
 	++m_sync_counter;
 
 	// appears to be a NOP *and* is called elsewhere.  wat?

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -935,7 +935,12 @@ class Blockchain
      * @param map return-by-reference the hashes for each block
      */
 	void block_longhash_worker(cn_pow_hash_v2 &hash_ctx, const std::vector<block> &blocks, std::unordered_map<crypto::hash, crypto::hash> &map);
-
+	/**
+     * @brief gets the local tick count when the last block was added
+     *
+     * @return tick count from when the last block was accepted to the main chain
+     */
+	uint64_t get_last_block_add_tick() const;
 	/**
      * @brief returns a set of known alternate chains
      *
@@ -1034,6 +1039,11 @@ class Blockchain
 
 	cn_pow_hash_v2 m_pow_ctx;
 	std::vector<cn_pow_hash_v2> m_hash_ctxes_multi;
+
+	// Local tick count from when the last block was accepted to the main chain.
+	std::atomic<uint64_t> m_last_block_add_tick{0};
+	// Updates the last block add tick to the current local tick count.
+	void set_last_block_add_tick();
 
 	checkpoints m_checkpoints;
 	bool m_enforce_dns_checkpoints;

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -283,6 +283,11 @@ uint64_t core::get_current_blockchain_height() const
 {
 	return m_blockchain_storage.get_current_blockchain_height();
 }
+
+uint64_t core::get_last_block_add_tick() const
+{
+	return m_blockchain_storage.get_last_block_add_tick();
+}
 //-----------------------------------------------------------------------------------------------
 void core::get_blockchain_top(uint64_t &height, crypto::hash &top_id) const
 {

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -316,6 +316,12 @@ class core : public i_miner_handler
 	uint64_t get_current_blockchain_height() const;
 
 	/**
+      * @copydoc Blockchain::get_last_block_add_tick
+      *
+      * @note see Blockchain::get_last_block_add_tick()
+      */
+	uint64_t get_last_block_add_tick() const;
+	/**
       * @brief get the hash and height of the most recent block
       *
       * @param height return-by-reference height of the block

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.h
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.h
@@ -125,6 +125,8 @@ class t_cryptonote_protocol_handler : public i_cryptonote_protocol, cryptonote_p
 	bool on_callback(cryptonote_connection_context &context);
 	t_core &get_core() { return m_core; }
 	bool is_synchronized() { return m_synchronized; }
+	// Returns true when the core accepted a block within the recent-block window.
+	bool was_block_added_recently() const;
 	void log_connections();
 	std::list<connection_info> get_connections();
 	const block_queue &get_block_queue() const { return m_block_queue; }

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -1556,6 +1556,15 @@ bool t_cryptonote_protocol_handler<t_core>::on_connection_synchronized()
 }
 //------------------------------------------------------------------------------------------------------------------------
 template <class t_core>
+bool t_cryptonote_protocol_handler<t_core>::was_block_added_recently() const
+{
+	// 10 minutes in milliseconds
+	constexpr uint64_t max_wait = 10*60*1000;
+	const uint64_t last = m_core.get_last_block_add_tick();
+	return last && epee::misc_utils::get_tick_count() - last <= max_wait;
+}
+//------------------------------------------------------------------------------------------------------------------------
+template <class t_core>
 size_t t_cryptonote_protocol_handler<t_core>::get_synchronizing_connections_count()
 {
 	size_t count = 0;

--- a/src/p2p/net_node.h
+++ b/src/p2p/net_node.h
@@ -250,6 +250,10 @@ class node_server : public epee::levin::levin_commands_handler<p2p_connection_co
 	size_t get_random_index_with_fixed_probability(size_t max_index);
 	bool is_peer_used(const peerlist_entry &peer);
 	bool is_peer_used(const anchor_peerlist_entry &peer);
+	// Returns true when at least one peer has completed the p2p handshake.
+	bool has_handshaked_peer();
+	// Mutes seed warnings when the daemon already has useful peer/sync state.
+	bool should_mute_seed_warnings();
 	bool is_addr_connected(const epee::net_utils::network_address &peer);
 	void add_upnp_port_mapping(uint32_t port);
 	void delete_upnp_port_mapping(uint32_t port);

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -986,7 +986,6 @@ bool node_server<t_payload_net_handler>::check_connection_and_handshake_with_pee
 }
 
 #undef priority_str
-
 //-----------------------------------------------------------------------------------
 template <class t_payload_net_handler>
 bool node_server<t_payload_net_handler>::is_addr_recently_failed(const epee::net_utils::network_address &addr)
@@ -1000,6 +999,27 @@ bool node_server<t_payload_net_handler>::is_addr_recently_failed(const epee::net
 		return false;
 	else
 		return true;
+}
+//-----------------------------------------------------------------------------------
+template<class t_payload_net_handler>
+bool node_server<t_payload_net_handler>::has_handshaked_peer()
+{
+	bool connected = false;
+	m_net_server.get_config_object().foreach_connection([&](const p2p_connection_context &cntxt) {
+    if(cntxt.peer_id)
+    {
+      connected = true;
+      return false;
+    }
+    return true;
+  });
+  return connected;
+}
+//-----------------------------------------------------------------------------------
+template <class t_payload_net_handler>
+bool node_server<t_payload_net_handler>::should_mute_seed_warnings() 
+{
+	return has_handshaked_peer() && (m_payload_handler.is_synchronized() || m_payload_handler.was_block_added_recently());
 }
 //-----------------------------------------------------------------------------------
 template <class t_payload_net_handler>
@@ -1115,6 +1135,7 @@ bool node_server<t_payload_net_handler>::make_new_connection_from_peerlist(bool 
 	}
 	return false;
 }
+
 //-----------------------------------------------------------------------------------
 template <class t_payload_net_handler>
 bool node_server<t_payload_net_handler>::connect_to_seed()
@@ -1136,7 +1157,16 @@ bool node_server<t_payload_net_handler>::connect_to_seed()
 		{
 			if(!fallback_nodes_added)
 			{
-				GULPS_WARN("Failed to connect to any of seed peers, trying fallback seeds");
+				constexpr const char *try_fall_seeds = "Failed to connect to any of seed peers, trying fallback seeds";
+				if(!should_mute_seed_warnings())
+				{
+					GULPS_WARN(try_fall_seeds);
+				}
+				else
+				{
+					GULPS_LOG_L1(try_fall_seeds);
+				}
+
 				for(const auto &peer : get_seed_nodes(m_nettype))
 				{
 					GULPSF_LOG_L1("Fallback seed node: {}", peer);
@@ -1147,7 +1177,16 @@ bool node_server<t_payload_net_handler>::connect_to_seed()
 			}
 			else
 			{
-				GULPS_WARN("Failed to connect to any of seed peers, continuing without seeds");
+				constexpr const char *con_without_seeds = "Failed to connect to any of seed peers, continuing without seeds";
+				if(!should_mute_seed_warnings())
+				{
+					GULPS_WARN(con_without_seeds);
+				}
+				else
+				{
+					GULPS_LOG_L1(con_without_seeds);
+				}
+
 				break;
 			}
 		}

--- a/tests/core_proxy/core_proxy.h
+++ b/tests/core_proxy/core_proxy.h
@@ -68,6 +68,8 @@ class proxy_core
 	void on_synchronized() {}
 	void safesyncmode(const bool) {}
 	uint64_t get_current_blockchain_height() { return 1; }
+	// Protocol handler core shim; these tests do not simulate recent block adds.
+	uint64_t get_last_block_add_tick() const { return 0; }
 	void set_target_blockchain_height(uint64_t) {}
 	bool init(const boost::program_options::variables_map &vm);
 	bool deinit() { return true; }

--- a/tests/unit_tests/ban.cpp
+++ b/tests/unit_tests/ban.cpp
@@ -53,6 +53,8 @@ class test_core
 	void on_synchronized() {}
 	void safesyncmode(const bool) {}
 	uint64_t get_current_blockchain_height() const { return 1; }
+	// Protocol handler core shim; these tests do not simulate recent block adds.
+	uint64_t get_last_block_add_tick() const { return 0; }
 	void set_target_blockchain_height(uint64_t) {}
 	bool init(const boost::program_options::variables_map &vm) { return true; }
 	bool deinit() { return true; }


### PR DESCRIPTION
## Summary

Downgrade the seed connection warning messages in `net_node.inl` when the daemon is already connected and either:

- synchronized, or
- has received a block within the last 10 minutes.

## Details

This adds a new blockchain member to track the tick when the most recent block was added. That value is passed through core and the cryptonote protocol handler so `net_node` can use it when deciding whether to mute the warning-level seed messages.

The core proxy and ban tests were also updated with the last block tick accessor for interface symmetry.