### PR TITLE
Hardfork Status

### DIFF
--- a/src/cryptonote_basic/hardfork.cpp
+++ b/src/cryptonote_basic/hardfork.cpp
@@ -355,19 +355,20 @@ int HardFork::get_voted_fork_index(uint64_t height) const
 	return current_fork_index;
 }
 
+// TODO: Implement some other up-to-date check
 HardFork::State HardFork::get_state(time_t t) const
 {
-	CRITICAL_REGION_LOCAL(lock);
+	// CRITICAL_REGION_LOCAL(lock);
 
-	// no hard forks setup yet
-	if(heights.size() <= 1)
-		return Ready;
+	// // no hard forks setup yet
+	// if(heights.size() <= 1)
+	// 	return Ready;
 
-	time_t t_last_fork = heights.back().time;
-	if(t >= t_last_fork + forked_time)
-		return LikelyForked;
-	if(t >= t_last_fork + update_time)
-		return UpdateNeeded;
+	// time_t t_last_fork = heights.back().time;
+	// if(t >= t_last_fork + forked_time)
+	// 	return LikelyForked;
+	// if(t >= t_last_fork + update_time)
+	// 	return UpdateNeeded;
 	return Ready;
 }
 


### PR DESCRIPTION
## Summary

 Keeps the node reporting `Ready` until a newer up-to-date check is implemented.

## Testing

Used ./ryod status to confirm the changes on local daemon.