### PR TITLE
docs(security): remove links to third-party-owned domains, add SECURITY.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,14 +54,14 @@ We have a solid track record and unique features that are not copied from other 
 
 ### Infrastructure
 - **[Ryo Wallet Atom](https://ryo-currency.com/atom)**. Modern, intuitive and rich with feature GUI wallet. Available for Windows, Linux and MacOSX.
-- **[Quasar Web wallet](https://ryowebwallet.com)**. Ultra-fast WEB based wallet that shares same design with Atom wallet.
-- **[Solo mining in GUI wallet](https://solo-pool.ryoblocks.com/getting-started)**. Built-in pool software with workers support, statistics and charts display.
 - **[Woo commerce plugin](https://github.com/ryo-currency/ryo-payments-woocommerce-gateway)**. Plug-in for web developers, to implement accepting Ryo on website.
 - **[Ryo Business room](https://ryo-currency.com/ryo-business-room)**. Business community of people fostering ecosystem development.
 
+> **Note:** The Quasar Web wallet (`ryowebwallet.com`) and the built-in Solo Mining Pool front-end (`solo-pool.ryoblocks.com`) are no longer maintained. The associated domains are no longer registered to the Ryo project and are now controlled by unrelated third parties &mdash; do **not** visit them or enter any wallet credentials there.
+
 GUI wallet | Web wallet | Cli wallet | Mobile | Hardware
 --- | --- | --- | --- | ---
-[v. 1.5.0](https://github.com/ryo-currency/ryo-wallet/releases/latest) | [Ryowebwallet](https://www.ryowebwallet.com/wallet-select) | [v. 0.5.0.0](https://github.com/ryo-currency/ryo-currency/releases/latest) | Developing | Planned
+[v. 1.5.0](https://github.com/ryo-currency/ryo-wallet/releases/latest) | Discontinued | [v. 0.5.0.0](https://github.com/ryo-currency/ryo-currency/releases/latest) | Developing | Planned
 
 ## Research and contributing
 With privacy and security as the core foundation of Ryo, we invest time and effort into security research as well as investigate and analyze issues with the Cryptonote protocol in order to bring true default anonymity for users.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,48 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+We appreciate responsible disclosure of security vulnerabilities affecting the
+Ryo Currency daemon, wallets, tooling, and infrastructure.
+
+Please report suspected vulnerabilities privately to:
+
+- **Email:** [contact@ryo-currency.com](mailto:contact@ryo-currency.com)
+
+Please **do not** open a public GitHub issue for security-sensitive reports.
+
+### What to include
+
+- A clear description of the vulnerability and its impact.
+- Steps to reproduce (proof-of-concept preferred).
+- Affected repository, branch/tag or commit hash, and file/line references.
+- The version of any binary or client affected.
+- Any suggested remediation, if you have one.
+
+### What to expect
+
+- We aim to acknowledge receipt of your report within a reasonable timeframe.
+- We will keep you updated as we investigate and, where appropriate, coordinate
+  disclosure of a fix.
+- We are happy to credit reporters in release notes unless you request otherwise.
+
+## Scope
+
+This policy applies to code in the `ryo-currency` GitHub organization,
+including but not limited to:
+
+- `ryo-currency/ryo-currency` (daemon)
+- `ryo-currency/ryo-wallet` (GUI wallet)
+- `ryo-currency/ryo-payments-woocommerce-gateway`
+- Any other repository maintained by the Ryo Currency Team
+
+Website and infrastructure issues affecting `ryo-currency.com` should also be
+sent to the address above.
+
+## Out of Scope
+
+- Third-party services and domains not owned or controlled by the Ryo Currency
+  project. In particular, historical infrastructure that has since been
+  abandoned by the project (for example, `ryowebwallet.com`, `ryoblocks.com`,
+  and their subdomains) is **not** operated by the Ryo Currency Team and is
+  not covered by this policy.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -38,11 +38,3 @@ including but not limited to:
 
 Website and infrastructure issues affecting `ryo-currency.com` should also be
 sent to the address above.
-
-## Out of Scope
-
-- Third-party services and domains not owned or controlled by the Ryo Currency
-  project. In particular, historical infrastructure that has since been
-  abandoned by the project (for example, `ryowebwallet.com`, `ryoblocks.com`,
-  and their subdomains) is **not** operated by the Ryo Currency Team and is
-  not covered by this policy.


### PR DESCRIPTION
## Context

Following the private security report sent to `contact@ryo-currency.com` on 2026-08-09 (and the team's reply of 2026-08-10 requesting a Pull Request), this PR fixes the highest-impact half of the finding: the README on `master`.

## Problem

The README currently links users to two domains that are **no longer registered to the Ryo Currency project** and are now controlled by unrelated third parties:

| Domain in README | Current owner / content |
| --- | --- |
| `https://ryowebwallet.com` (line 57) | Registered via `NameSilo, LLC` (creation 2019-03-16, updated 2026-07-29). Currently serves `ManBetX体育` (Chinese sports-betting brand). |
| `https://solo-pool.ryoblocks.com/getting-started` (line 58) | Parent `ryoblocks.com` re-registered via `DYNADOT LLC` on 2024-08-27. Apex serves a Russian used-car page (WordPress + PHP/7.4.33). |
| `https://www.ryowebwallet.com/wallet-select` (line 64, wallet table) | Same as row 1. |

Ryo used to own both:

- <https://web.archive.org/web/20210117025138/https://solo-pool.ryoblocks.com/> &mdash; *Ryo Solo Pool Frontend*
- <https://web.archive.org/web/20210117100924/https://www.ryowebwallet.com/> &mdash; *Ryo Wallet Quasar*

Because the README is the first page every new user, potential contributor, or new-installer sees on GitHub, following these links today can direct users to phishing content. Under the current squatter it is a scam site; under a more targeted squatter it can trivially become a wallet-credential harvester.

## Changes

### `README.md`
- Removed the two Infrastructure bullets pointing to `ryowebwallet.com` and `solo-pool.ryoblocks.com`.
- Added a short note in the Infrastructure section explicitly telling users these domains are no longer controlled by the project and should not be visited.
- Replaced the `Ryowebwallet` cell in the wallet table with the text `Discontinued` &mdash; no live link remains.

### `SECURITY.md` (new)
- Adds a responsible-disclosure contact (`contact@ryo-currency.com`) so future reporters have a canonical channel.
- Explicitly notes that abandoned third-party infrastructure (`ryowebwallet.com`, `ryoblocks.com`, subdomains) is out of scope of the project.

No functional / daemon / consensus code is touched.

## Verification

```console
$ grep -nE 'ryowebwallet|ryoblocks' README.md
# Only the informational note line matches; no live links remain.
```

## Related PRs

- `ryo-currency/ryo-wallet` &mdash; testnet-explorer hardcode (`tnexp.ryoblocks.com`) fix (linked once opened).
- `ryo-currency/ryo-wallet-libre` &mdash; mainnet default remote-daemon (`geo.ryoblocks.com`) fix (linked once opened).

## Additional recommendation (not in this PR)

Both squatted domains have upcoming expirations:

- `ryoblocks.com` &mdash; expires `2026-08-27` (~18 days from PR).
- `ryowebwallet.com` &mdash; expires `2027-03-16`.

The most durable fix is for the Ryo team to attempt drop-catch through a specialist (SnapNames / Dynadot backorder / NameJet) to re-acquire the domains before they can be re-weaponised. This obviously cannot be done in a PR.